### PR TITLE
Fix annoying UI bug

### DIFF
--- a/GameContent/UI/GameUI.cs
+++ b/GameContent/UI/GameUI.cs
@@ -282,6 +282,26 @@ namespace TanksRebirth.GameContent.UI
                 MainMenu.MenuState = MainMenu.State.PlayList;
             if (MainMenu.MenuState == MainMenu.State.StatsMenu)
                 MainMenu.MenuState = MainMenu.State.PrimaryMenu;
+
+            // We are on the main menu and in the settings menu.
+            if (MainMenu.MenuState == MainMenu.State.Options && MainMenu.Active) {
+                // Set to main menu, we are going back to it after all.
+                MainMenu.MenuState = MainMenu.State.PrimaryMenu;
+                
+                // Hide Options buttons and load MMenu buttons.
+                MainMenu.PlayButton.IsVisible = true;
+                OptionsButton.IsVisible = true;
+                QuitButton.IsVisible = true;
+                
+                ResumeButton.IsVisible = false;
+                RestartButton.IsVisible = false;
+                BackButton.IsVisible = false;
+                ControlsButton.IsVisible = false;
+                GraphicsButton.IsVisible = false;
+                VolumeButton.IsVisible = false;
+            }
+            
+
             if (VolumeButton.IsVisible && !MainMenu.Active)
             {
                 ResumeButton.IsVisible = true;

--- a/GameContent/UI/GameUI.cs
+++ b/GameContent/UI/GameUI.cs
@@ -284,7 +284,7 @@ namespace TanksRebirth.GameContent.UI
                 MainMenu.MenuState = MainMenu.State.PrimaryMenu;
 
             // We are on the main menu and in the settings menu.
-            if (MainMenu.MenuState == MainMenu.State.Options && MainMenu.Active) {
+            if (MainMenu.MenuState == MainMenu.State.Options && MainMenu.Active && VolumeButton.IsVisible != false) {
                 // Set to main menu, we are going back to it after all.
                 MainMenu.MenuState = MainMenu.State.PrimaryMenu;
                 


### PR DESCRIPTION
This commit aims to fix the annoying UI bug that occurs after YOU, the player, dies in game, gets kicked to the main menu, and decides to open the Options menu. Going back after that happens will make the UI glitch entirely, this funky patch aims to fix just that.