### PR TITLE
Supply the check point when sending the name of the campaign.

### DIFF
--- a/GameContent/UI/MainMenu.cs
+++ b/GameContent/UI/MainMenu.cs
@@ -830,8 +830,8 @@ namespace TanksRebirth.GameContent.UI
 
             if (!netRecieved && !wasConfirmed) { // when switch, do !wasConfirmed && !netRecieved
                 if (Client.IsConnected()) {
-                    //Client.SendCampaignBytes(camp);
-                    Client.SendCampaignByName(name);
+                    Client.SendCampaignByName(name, MissionCheckpoint);
+                    // Client.SendCampaignBytes(camp);
                     return true;
                 }
             }

--- a/Net/Client.cs
+++ b/Net/Client.cs
@@ -323,14 +323,15 @@ namespace TanksRebirth.Net
             client.Send(message, DeliveryMethod.Sequenced);
         }
 
-        public static void SendCampaignByName(string name) {
+        public static void SendCampaignByName(string name, int checkPoint) {
             if (!IsConnected())
                 return;
             NetDataWriter message = new();
             message.Put(PacketID.SendCampaignByName);
 
             message.Put(name);
-
+            message.Put(checkPoint);
+            
             client.Send(message, DeliveryMethod.ReliableOrdered);
         }
         public static void SendDisconnect(int peerId, string name, string reason) {

--- a/Net/NetPlay.cs
+++ b/Net/NetPlay.cs
@@ -319,8 +319,10 @@ namespace TanksRebirth.Net
                     break;
                 case PacketID.SendCampaignByName:
                     var campName = reader.GetString();
-
+                    var checkPoint = reader.GetInt();
                     // if this solution fails, simply change param 2 (wasConfirmed) to true
+                    MainMenu.MissionCheckpoint = checkPoint; // Set the given id.
+
                     var success = MainMenu.PrepareGameplay(campName, false, true); // second param to false when doing a check
                     Client.SendCampaignStatus(campName, CurrentClient.Id, success); // if this player doesn't own said campaign, cancel the operation.
                     if (success)
@@ -625,7 +627,9 @@ namespace TanksRebirth.Net
                     break;
                 case PacketID.SendCampaignByName:
                     var campName = reader.GetString();
+                    var campaignId = reader.GetInt();
                     message.Put(campName);
+                    message.Put(campaignId);
 
                     Server.serverNetManager.SendToAll(message, DeliveryMethod.Sequenced, peer);
                     break;


### PR DESCRIPTION
This attempts to fix the UB that occurs when you want to load a mission that is not the first one in a campaign.

How does this work? Ofc magic. We just supply the clients with the mission number we are going to load, then profit!