### PR TITLE
Level editor bug fix.

### DIFF
--- a/GameContent/PlayerTank.cs
+++ b/GameContent/PlayerTank.cs
@@ -192,7 +192,9 @@ namespace TanksRebirth.GameContent
             // 3/4pi = left
 
             base.Update();
-
+            
+            if (LevelEditor.Active) return;
+            
             if (NetPlay.IsClientMatched(PlayerId))
                 Client.SyncPlayerTank(this);
 

--- a/GameContent/Systems/Campaign.cs
+++ b/GameContent/Systems/Campaign.cs
@@ -108,7 +108,7 @@ namespace TanksRebirth.GameContent.Systems
             // FIXME: source of level editor bug.
             PlacementSquare.ResetSquares();
             GameHandler.CleanupEntities();
-
+            const int roundingFactor = 5;
             int numPlayers = 0;
             for (int i = 0; i < LoadedMission.Tanks.Length; i++)
             {
@@ -125,9 +125,9 @@ namespace TanksRebirth.GameContent.Systems
                         var tank = template.GetAiTank();
 
                         tank.Position = template.Position;
-                        tank.TankRotation = template.Rotation;
-                        tank.TargetTankRotation = template.Rotation;
-                        tank.TurretRotation = -template.Rotation;
+                        tank.TankRotation = MathF.Round(template.Rotation, roundingFactor);
+                        tank.TargetTankRotation = MathF.Round(template.Rotation, roundingFactor);
+                        tank.TurretRotation = MathF.Round(template.Rotation, roundingFactor);
                         tank.Dead = false;
                         tank.Team = template.Team;
                         if (GameProperties.ShouldMissionsProgress)
@@ -154,7 +154,8 @@ namespace TanksRebirth.GameContent.Systems
                         var tank = template.GetPlayerTank();
 
                         tank.Position = template.Position;
-                        tank.TankRotation = template.Rotation;
+                        tank.TankRotation = MathF.Round(template.Rotation, roundingFactor);
+                        tank.TargetTankRotation = MathF.Round(template.Rotation, roundingFactor);
                         tank.Dead = false;
                         tank.Team = template.Team;
 
@@ -186,9 +187,9 @@ namespace TanksRebirth.GameContent.Systems
                                 // turret =  -rot
                                 Position = template.Position,
                                 Team = tank.Team,
-                                TankRotation = template.Rotation,
-                                TargetTankRotation = -template.Rotation,
-                                TurretRotation = template.Rotation,
+                                TankRotation = MathF.Round(template.Rotation, roundingFactor),
+                                TargetTankRotation = MathF.Round(template.Rotation, roundingFactor),
+                                TurretRotation = MathF.Round(template.Rotation, roundingFactor),
                                 Dead = false
                             };
                             tnk.Body.Position = template.Position;

--- a/GameContent/Systems/Campaign.cs
+++ b/GameContent/Systems/Campaign.cs
@@ -118,6 +118,15 @@ namespace TanksRebirth.GameContent.Systems
                     TrackedSpawnPoints[i].Item1 = LoadedMission.Tanks[i].Position;
                     TrackedSpawnPoints[i].Item2 = true;
                 }
+
+                while (template.Rotation < 0) {
+                    template.Rotation += MathHelper.Tau;
+                }
+                
+                while (template.Rotation > MathHelper.Tau) {
+                    template.Rotation -= MathHelper.Tau;
+                }
+                
                 if (!template.IsPlayer)
                 {
                     if (TrackedSpawnPoints[i].Item2)
@@ -127,7 +136,7 @@ namespace TanksRebirth.GameContent.Systems
                         tank.Position = template.Position;
                         tank.TankRotation = MathF.Round(template.Rotation, roundingFactor);
                         tank.TargetTankRotation = MathF.Round(template.Rotation, roundingFactor);
-                        tank.TurretRotation = MathF.Round(template.Rotation, roundingFactor);
+                        tank.TurretRotation = MathF.Round(-template.Rotation, roundingFactor);
                         tank.Dead = false;
                         tank.Team = template.Team;
                         if (GameProperties.ShouldMissionsProgress)
@@ -156,6 +165,7 @@ namespace TanksRebirth.GameContent.Systems
                         tank.Position = template.Position;
                         tank.TankRotation = MathF.Round(template.Rotation, roundingFactor);
                         tank.TargetTankRotation = MathF.Round(template.Rotation, roundingFactor);
+                        tank.TurretRotation = MathF.Round(-template.Rotation, roundingFactor);
                         tank.Dead = false;
                         tank.Team = template.Team;
 
@@ -189,7 +199,7 @@ namespace TanksRebirth.GameContent.Systems
                                 Team = tank.Team,
                                 TankRotation = MathF.Round(template.Rotation, roundingFactor),
                                 TargetTankRotation = MathF.Round(template.Rotation, roundingFactor),
-                                TurretRotation = MathF.Round(template.Rotation, roundingFactor),
+                                TurretRotation = MathF.Round(-template.Rotation, roundingFactor),
                                 Dead = false
                             };
                             tnk.Body.Position = template.Position;

--- a/GameContent/Systems/Mission.cs
+++ b/GameContent/Systems/Mission.cs
@@ -53,8 +53,8 @@ namespace TanksRebirth.GameContent.Systems
         /// Creates a <see cref="Mission"/> instance from the current placement of everything.
         /// </summary>
         /// <returns>The mission that is currently active, or created.</returns>
-        public static Mission GetCurrent(string name = null)
-        {
+        public static Mission GetCurrent(string name = null) {
+            const int roundingFactor = 5;
             List<TankTemplate> tanks = new();
             List<BlockTemplate> blocks = new();
 
@@ -66,7 +66,7 @@ namespace TanksRebirth.GameContent.Systems
                     {
                         IsPlayer = tank is PlayerTank,
                         Position = tank.Position,
-                        Rotation = tank.TankRotation,
+                        Rotation = MathF.Round(tank.TankRotation, roundingFactor),
                         Team = tank.Team,
                     };
 

--- a/GameContent/Tank.cs
+++ b/GameContent/Tank.cs
@@ -24,8 +24,7 @@ using TanksRebirth.Net;
 
 namespace TanksRebirth.GameContent;
 
-public struct TankTemplate
-{
+public struct TankTemplate {
     /// <summary>If false, the template will contain data for an AI tank.</summary>
     public bool IsPlayer;
 
@@ -34,7 +33,12 @@ public struct TankTemplate
 
     public Vector2 Position;
 
-    public float Rotation;
+    private float backingRotationField;
+
+    public float Rotation { // Rounded to avoid issues when calculating rotation.
+        get => backingRotationField;
+        set => backingRotationField = MathF.Round(value, 4);
+    }
 
     public int Team;
 

--- a/GameContent/Tank.cs
+++ b/GameContent/Tank.cs
@@ -33,11 +33,11 @@ public struct TankTemplate {
 
     public Vector2 Position;
 
-    private float backingRotationField;
+    private float _backingRotationField;
 
     public float Rotation { // Rounded to avoid issues when calculating rotation.
-        get => backingRotationField;
-        set => backingRotationField = MathF.Round(value, 4);
+        get => _backingRotationField;
+        set => _backingRotationField = MathF.Round(value, 5);
     }
 
     public int Team;

--- a/TankGame.cs
+++ b/TankGame.cs
@@ -837,27 +837,12 @@ namespace TanksRebirth
                                 {
                                     tnk.TankRotation -= MathHelper.PiOver2;
                                     tnk.TurretRotation -= MathHelper.PiOver2;
-                                    if (tnk is AITank ai)
-                                    {
-                                        ai.TargetTankRotation += MathHelper.PiOver2;
+                                    
+                                    tnk.TargetTankRotation += MathHelper.PiOver2;
 
-                                        if (ai.TargetTankRotation >= MathHelper.Tau)
-                                            ai.TargetTankRotation -= MathHelper.Tau;
+                                    if (tnk.TargetTankRotation >= MathHelper.Tau)
+                                        tnk.TargetTankRotation -= MathHelper.Tau;
 
-                                        //if (ai.TargetTankRotation >= MathHelper.Tau)
-                                            //ai.TargetTankRotation -= MathHelper.Tau;
-                                        //if (ai.TargetTankRotation <= 0)
-                                            //ai.TargetTankRotation += MathHelper.Tau;
-                                    }
-                                    else {
-                                        // TODO: This solution causes the player tank to stutter if the rotation is **TOO FAST**.
-                                        // Preferably coming up with a better solution than this is better
-                                        tnk.TargetTankRotation -= MathHelper.PiOver2;
-
-                                        if (tnk.TargetTankRotation <= MathHelper.Tau)
-                                            tnk.TargetTankRotation += MathHelper.Tau;
-
-                                    }
                                     if (tnk.TankRotation <= -MathHelper.Tau)
                                         tnk.TankRotation += MathHelper.Tau;
 

--- a/TankGame.cs
+++ b/TankGame.cs
@@ -833,20 +833,31 @@ namespace TanksRebirth
                                         tnk?.Destroy(new TankHurtContext_Other()); // hmmm
                                 }
 
-                                if (InputUtils.CanDetectClick(rightClick: true)) {
+                                if (InputUtils.CanDetectClick(rightClick: true))
+                                {
                                     tnk.TankRotation -= MathHelper.PiOver2;
-                                    tnk.TurretRotation -= MathHelper.Tau;
-                                    
-                                    tnk.TargetTankRotation += MathHelper.PiOver2;
+                                    tnk.TurretRotation -= MathHelper.PiOver2;
+                                    if (tnk is AITank ai)
+                                    {
+                                        ai.TargetTankRotation += MathHelper.PiOver2;
 
-                                    if (tnk.TargetTankRotation >= MathHelper.Tau)
-                                        tnk.TargetTankRotation -= MathHelper.Tau;
+                                        if (ai.TargetTankRotation >= MathHelper.Tau)
+                                            ai.TargetTankRotation -= MathHelper.Tau;
 
-                                    //if (ai.TargetTankRotation >= MathHelper.Tau)
-                                        //ai.TargetTankRotation -= MathHelper.Tau;
-                                    //if (ai.TargetTankRotation <= 0)
-                                        //ai.TargetTankRotation += MathHelper.Tau;
-                                    
+                                        //if (ai.TargetTankRotation >= MathHelper.Tau)
+                                            //ai.TargetTankRotation -= MathHelper.Tau;
+                                        //if (ai.TargetTankRotation <= 0)
+                                            //ai.TargetTankRotation += MathHelper.Tau;
+                                    }
+                                    else {
+                                        // TODO: This solution causes the player tank to stutter if the rotation is **TOO FAST**.
+                                        // Preferably coming up with a better solution than this is better
+                                        tnk.TargetTankRotation -= MathHelper.PiOver2;
+
+                                        if (tnk.TargetTankRotation <= MathHelper.Tau)
+                                            tnk.TargetTankRotation += MathHelper.Tau;
+
+                                    }
                                     if (tnk.TankRotation <= -MathHelper.Tau)
                                         tnk.TankRotation += MathHelper.Tau;
 

--- a/TankGame.cs
+++ b/TankGame.cs
@@ -833,31 +833,20 @@ namespace TanksRebirth
                                         tnk?.Destroy(new TankHurtContext_Other()); // hmmm
                                 }
 
-                                if (InputUtils.CanDetectClick(rightClick: true))
-                                {
+                                if (InputUtils.CanDetectClick(rightClick: true)) {
                                     tnk.TankRotation -= MathHelper.PiOver2;
-                                    tnk.TurretRotation -= MathHelper.PiOver2;
-                                    if (tnk is AITank ai)
-                                    {
-                                        ai.TargetTankRotation += MathHelper.PiOver2;
+                                    tnk.TurretRotation -= MathHelper.Tau;
+                                    
+                                    tnk.TargetTankRotation += MathHelper.PiOver2;
 
-                                        if (ai.TargetTankRotation >= MathHelper.Tau)
-                                            ai.TargetTankRotation -= MathHelper.Tau;
+                                    if (tnk.TargetTankRotation >= MathHelper.Tau)
+                                        tnk.TargetTankRotation -= MathHelper.Tau;
 
-                                        //if (ai.TargetTankRotation >= MathHelper.Tau)
-                                            //ai.TargetTankRotation -= MathHelper.Tau;
-                                        //if (ai.TargetTankRotation <= 0)
-                                            //ai.TargetTankRotation += MathHelper.Tau;
-                                    }
-                                    else {
-                                        // TODO: This solution causes the player tank to stutter if the rotation is **TOO FAST**.
-                                        // Preferably coming up with a better solution than this is better
-                                        tnk.TargetTankRotation -= MathHelper.PiOver2;
-
-                                        if (tnk.TargetTankRotation <= MathHelper.Tau)
-                                            tnk.TargetTankRotation += MathHelper.Tau;
-
-                                    }
+                                    //if (ai.TargetTankRotation >= MathHelper.Tau)
+                                        //ai.TargetTankRotation -= MathHelper.Tau;
+                                    //if (ai.TargetTankRotation <= 0)
+                                        //ai.TargetTankRotation += MathHelper.Tau;
+                                    
                                     if (tnk.TankRotation <= -MathHelper.Tau)
                                         tnk.TankRotation += MathHelper.Tau;
 

--- a/TankGame.cs
+++ b/TankGame.cs
@@ -835,6 +835,31 @@ namespace TanksRebirth
 
                                 if (InputUtils.CanDetectClick(rightClick: true))
                                 {
+                                    while (tnk.TankRotation < 0) {
+                                        tnk.TankRotation += MathHelper.Tau;
+                                    }
+                
+                                    while (tnk.TankRotation > MathHelper.Tau) {
+                                        tnk.TankRotation -= MathHelper.Tau;
+                                    }
+                                    
+                                    while (tnk.TargetTankRotation < 0) {
+                                        tnk.TargetTankRotation += MathHelper.Tau;
+                                    }
+                
+                                    while (tnk.TargetTankRotation > MathHelper.Tau) {
+                                        tnk.TargetTankRotation -= MathHelper.Tau;
+                                    }
+                                                                        
+                                    while (tnk.TurretRotation < 0) {
+                                        tnk.TurretRotation += MathHelper.Tau;
+                                    }
+                
+                                    while (tnk.TurretRotation > MathHelper.Tau) {
+                                        tnk.TurretRotation -= MathHelper.Tau;
+                                    }
+                                    
+                                    
                                     tnk.TankRotation -= MathHelper.PiOver2;
                                     tnk.TurretRotation -= MathHelper.PiOver2;
                                     
@@ -848,6 +873,7 @@ namespace TanksRebirth
 
                                     if (tnk.TurretRotation <= -MathHelper.Tau)
                                         tnk.TurretRotation += MathHelper.Tau;
+                                    
                                 }
 
                                 tnk.IsHoveredByMouse = true;


### PR DESCRIPTION
This attempts to fix some problems by rounding the the rotation to four values, this is less precise than the value used to calculate rotation in-code, this should fix the spazzing seen in the editor when loading a save with a change as minimal as `0.0000001`. Yes. This happens (for example) if you open Mission 3 from the Vanilla campaign, where this occurs.

This also normalizes the values that are used to rotate the tanks, bringing values like 12 back to 3.14 for example (**probably not accurate math, cannot be asked to check if it is right.**).

## Affected Tank:
![image](https://user-images.githubusercontent.com/107165614/229257163-f99f0532-3a9e-4099-aebe-d1edfb6063bd.png)

## Not Affected Tank:
![image](https://i.imgur.com/4g4Ylfi.png)
