### PR TITLE
Please, Ryan, don't break them again, I HAVE NIGHTMARES OF THIS NUMBERS.

### DIFF
--- a/GameContent/Systems/Mission.cs
+++ b/GameContent/Systems/Mission.cs
@@ -105,6 +105,8 @@ namespace TanksRebirth.GameContent.Systems
             GameHandler.CleanupScene();
             for (int i = 0; i < mission.Tanks.Length; i++) {
                 var tnk = mission.Tanks[i];
+                tnk.Rotation = tnk.Rotation; // Use setter for magical purposes.
+                
                 var tank = tnk.GetTank();
 
                 var placement = PlacementSquare.Placements.FindIndex(place => Vector3.Distance(place.Position, tank.Position3D) < Block.FULL_BLOCK_SIZE / 2);
@@ -116,10 +118,10 @@ namespace TanksRebirth.GameContent.Systems
                 }
 
                 // FIXME: relates to tank rotation.
-                tank.TankRotation = tnk.Rotation;
+                tank.TankRotation = -MathF.Round(tnk.Rotation, 5);
                 // REMINDER: go here if you're editing load values again.
                 tank.TargetTankRotation = -tank.TankRotation;
-
+                tank.TurretRotation = -tank.TurretRotation;
                 // FIXME: tanks placed on a horizontal axis (left, right) are flipped upon loading directly. fix that.
             }
             for (int i = 0; i < mission.Blocks.Length; i++) {

--- a/GameContent/Systems/TankSystem/PlayerTank.cs
+++ b/GameContent/Systems/TankSystem/PlayerTank.cs
@@ -225,7 +225,7 @@ namespace TanksRebirth.GameContent
                     if (!Difficulties.Types["ThirdPerson"] || LevelEditor.Active || MainMenu.Active) {
                         Vector3 mouseWorldPos = MatrixUtils.GetWorldPosition(MouseUtils.MousePosition, -11f);
                         if (!LevelEditor.Active)
-                            TurretRotation = (-(new Vector2(mouseWorldPos.X, mouseWorldPos.Z) - Position).ToRotation()) + MathHelper.PiOver2;
+                            TurretRotation = -(new Vector2(mouseWorldPos.X, mouseWorldPos.Z) - Position).ToRotation() + MathHelper.PiOver2;
                         else
                             TurretRotation = TankRotation;
                     }

--- a/GameContent/Systems/TankSystem/TankTemplate.cs
+++ b/GameContent/Systems/TankSystem/TankTemplate.cs
@@ -60,6 +60,7 @@ public struct TankTemplate {
         player.Body.Position = Position / Tank.UNITS_PER_METER;
         player.Position = Position;
         player.TankRotation = Rotation;
+        player.TurretRotation = Rotation;
         player.Dead = false;
         player.Team = Team;
 


### PR DESCRIPTION
- Fixes player rotating its tank, yet not its turret. (It wasn't mapped correctly during the conversion of TankTemplate to PlayerTank)
- Fixes Tanks incorrectly rotating their turret. (The rotation was correctly set to negative, but not the turret)