### PR TITLE
Fix multiplayer + UI bug

### DIFF
--- a/GameContent/UI/MainMenu.cs
+++ b/GameContent/UI/MainMenu.cs
@@ -803,8 +803,12 @@ namespace TanksRebirth.GameContent.UI
         }
         // this is super workaround-y.
         internal static int plrsConfirmed;
-        public static bool PrepareGameplay(string name, bool wasConfirmed = true, bool netRecieved = false)
-        {
+        public static bool PrepareGameplay(string name, bool wasConfirmed = true, bool netRecieved = false, int? missionId = null) {
+            if (missionId.HasValue) {
+                ChatSystem.SendMessage("We have received a custom mission identifier", Color.Green);
+                MissionCheckpoint = missionId.Value;
+            }
+
             // FIXME: find the feedback loop that causes the recieving client to start a mission anyway...
             
             var path = Path.Combine("Campaigns", name + ".campaign");
@@ -831,7 +835,7 @@ namespace TanksRebirth.GameContent.UI
             if (!netRecieved && !wasConfirmed) { // when switch, do !wasConfirmed && !netRecieved
                 if (Client.IsConnected()) {
                     //Client.SendCampaignBytes(camp);
-                    Client.SendCampaignByName(name);
+                    Client.SendCampaignByName(name, MissionCheckpoint);
                     return true;
                 }
             }

--- a/Internals/UI/UIElement.cs
+++ b/Internals/UI/UIElement.cs
@@ -370,12 +370,12 @@ namespace TanksRebirth.Internals.UI
                 if (element == null) continue;
                 if (!element._doUpdating) continue;
                 // this may need revertation. 
-                /* element.Position = element.InternalPosition =
+                 element.Position = element.InternalPosition =
                     element._updatedPos.Invoke() + element.Offset.ToResolution();
-                element.Size = element.InternalSize = element._updatedSize.Invoke();*/
-                element.Position = element.InternalPosition =
+                element.Size = element.InternalSize = element._updatedSize.Invoke();
+                /*element.Position = element.InternalPosition =
                     element._updatedPos.Invoke().ToResolution() + element.Offset.ToResolution();
-                element.Size = element.InternalSize = element._updatedSize.Invoke().ToResolution();
+                element.Size = element.InternalSize = element._updatedSize.Invoke().ToResolution();*/
             }
         }
 

--- a/Net/Client.cs
+++ b/Net/Client.cs
@@ -323,13 +323,14 @@ namespace TanksRebirth.Net
             client.Send(message, DeliveryMethod.Sequenced);
         }
 
-        public static void SendCampaignByName(string name) {
+        public static void SendCampaignByName(string name, int missionId) {
             if (!IsConnected())
                 return;
             NetDataWriter message = new();
             message.Put(PacketID.SendCampaignByName);
 
             message.Put(name);
+            message.Put(missionId);
 
             client.Send(message, DeliveryMethod.ReliableOrdered);
         }

--- a/Net/NetPlay.cs
+++ b/Net/NetPlay.cs
@@ -318,12 +318,13 @@ namespace TanksRebirth.Net
                     break;
                 case PacketID.SendCampaignByName:
                     var campName = reader.GetString();
+                    var missionId = reader.GetInt();        // Obtain the mission id from the server itself. Fixes issues when loading missions.
 
                     // if this solution fails, simply change param 2 (wasConfirmed) to true
-                    var success = MainMenu.PrepareGameplay(campName, false, true); // second param to false when doing a check
+                    var success = MainMenu.PrepareGameplay(campName, false, true, missionId); // second param to false when doing a check
                     Client.SendCampaignStatus(campName, CurrentClient.Id, success); // if this player doesn't own said campaign, cancel the operation.
                     if (success) {
-                        MainMenu.PrepareGameplay(campName, true, true);
+                        MainMenu.PrepareGameplay(campName, true, true, missionId);
                     }
                     break;
                 case PacketID.Cleanup:
@@ -625,7 +626,9 @@ namespace TanksRebirth.Net
                     break;
                 case PacketID.SendCampaignByName:
                     var campName = reader.GetString();
+                    var missionId = reader.GetInt();
                     message.Put(campName);
+                    message.Put(missionId);
 
                     Server.serverNetManager.SendToAll(message, DeliveryMethod.Sequenced, peer);
                     break;


### PR DESCRIPTION
This commit fixes a bug that occurs when loading a campaign, when its mission id is different than the default. It fixes is by making the server also send the mission with the campaign name.

Fixes UI bug introduced in 24de10d where the UI would break on high resolutions.