### PR TITLE
Fixes

### DIFF
--- a/GameContent/Systems/Mission.cs
+++ b/GameContent/Systems/Mission.cs
@@ -98,7 +98,7 @@ public record struct Mission {
             // FIXME: relates to tank rotation.
             tank.TankRotation = MathF.Round(tnk.Rotation, 5);
             // REMINDER: go here if you're editing load values again.
-            tank.TargetTankRotation = -tank.TankRotation;
+            tank.TargetTankRotation = tank.TankRotation;
             tank.TurretRotation = tank.TurretRotation;
             // FIXME: tanks placed on a horizontal axis (left, right) are flipped upon loading directly. fix that.
         }

--- a/Internals/UI/UIElementMouseInput.cs
+++ b/Internals/UI/UIElementMouseInput.cs
@@ -60,7 +60,7 @@ namespace TanksRebirth.Internals.UI {
             List<UIElement> focusedElements = new(AllUIElements.Count / 8);
 
             if (!getHighest) {
-                for (var iterator = AllUIElements.Count; iterator >= 0; iterator--) {
+                for (var iterator = AllUIElements.Count - 1; iterator >= 0; iterator--) {
                     var currentElement = AllUIElements[iterator];
                     if (currentElement.IgnoreMouseInteractions || !currentElement.IsVisible || !currentElement.Hitbox.Contains(position))
                         continue;

--- a/TankGame.cs
+++ b/TankGame.cs
@@ -870,6 +870,13 @@ public class TankGame : Game {
                                     if (tnk.TargetTankRotation >= MathHelper.Tau)
                                         tnk.TargetTankRotation -= MathHelper.Tau;
 
+                                    if (tnk is AITank aiTank) {
+                                        aiTank.TargetTurretRotation += MathHelper.Tau;
+
+                                        if (aiTank.TargetTurretRotation >= MathHelper.Tau)
+                                            aiTank.TargetTurretRotation -= MathHelper.Tau;
+                                    }
+
                                     if (tnk.TankRotation <= -MathHelper.Tau)
                                         tnk.TankRotation += MathHelper.Tau;
 


### PR DESCRIPTION
- Fixed rotation bug that occured when returning from Testing to Editor, which would rotate tanks of the rotation of the tank was equal to ~1.57. This is a bizarre bug, I do not know why it occurs, so it's simply a hack fix.

- Fixed a bug where the user could break the sequence that leads them from the Main Menu to the Editor, which would cause it to  leak `Task` objects and make it so the game would enter into the editor the next time it had a fade out occur. 