### PR TITLE
Fix case-sensitive path on linux

### DIFF
--- a/GameContent/GameShaders.cs
+++ b/GameContent/GameShaders.cs
@@ -30,10 +30,10 @@ public class GameShaders
     }
 
     public static void Initialize() {
-        GaussianBlurShader = GameResources.GetGameResource<Effect>("Assets/Shaders/gaussian_blur");
-        MouseShader = GameResources.GetGameResource<Effect>("Assets/Shaders/mouse");
-        LanternShader = GameResources.GetGameResource<Effect>("Assets/Shaders/lantern");
-        AnimatedRainbow = GameResources.GetGameResource<Effect>("Assets/Shaders/rainbow_grad_anim");
+        GaussianBlurShader = GameResources.GetGameResource<Effect>("Assets/shaders/gaussian_blur");
+        MouseShader = GameResources.GetGameResource<Effect>("Assets/shaders/mouse");
+        LanternShader = GameResources.GetGameResource<Effect>("Assets/shaders/lantern");
+        AnimatedRainbow = GameResources.GetGameResource<Effect>("Assets/shaders/rainbow_grad_anim");
     }
     //static float val = 1f;
     public static void UpdateShaders() {


### PR DESCRIPTION
On linux, project would crash at launch with log : 

```
XXXX:~/Games/other/tanks_rebirth_v1.8_linux-x64$ ./TanksRebirth 
Unhandled exception. Microsoft.Xna.Framework.Content.ContentLoadException: The content file was not found.
 ---> System.IO.FileNotFoundException: Content/Assets/Shaders/gaussian_blur.xnb
 ---> System.IO.DirectoryNotFoundException: Could not find a part of the path '/home/XXXX/Games/other/tanks_rebirth_v1.8_linux-x64/Content/Assets/Shaders/gaussian_blur.xnb'.
   at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirError)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String path, OpenFlags flags, Int32 mode, Boolean failForSymlink, Boolean& wasSymlink, Func`4 createOpenException)
```

Workaround was creating a copy of the "shaders" folder alongside it named "Shaders".
This is because of case-sensitivity of paths.


- [ ] - I have NOT tested the fix with a build, as my env is not set up for .net