### PR TITLE
Add two-player local co-op with optional POV split-screen

### DIFF
--- a/GameContent/GameHandler.cs
+++ b/GameContent/GameHandler.cs
@@ -212,10 +212,10 @@ public class GameHandler {
         OnPostUpdate?.Invoke();
     }
 
-    internal static void RenderAll() {
+    internal static void RenderAll(bool includeSharedHud = true) {
         TankGame.Instance.GraphicsDevice.BlendState = BlendState.AlphaBlend;
 
-        if (!MainMenuUI.IsActive && !LevelEditorUI.IsEditing) {
+        if (includeSharedHud && !MainMenuUI.IsActive && !LevelEditorUI.IsEditing) {
             ExperienceBar.Position = new(WindowUtils.WindowWidth / 2 - ExperienceBar.Scale.X / 2, 50);
             ExperienceBar.Scale = new(600, 20);
             ExperienceBar.Alignment = Anchor.LeftCenter;

--- a/GameContent/GameHandler.cs
+++ b/GameContent/GameHandler.cs
@@ -24,6 +24,7 @@ using TanksRebirth.Graphics.Metrics;
 using TanksRebirth.GameContent.Systems.ParticleSystem;
 using TanksRebirth.GameContent.Systems.AI;
 using TanksRebirth.GameContent.Systems.TankSystem;
+using TanksRebirth.GameContent.Systems.LocalCoop;
 
 namespace TanksRebirth.GameContent;
 
@@ -117,7 +118,14 @@ public class GameHandler {
         var floor0 = MathF.Floor(TankGame.GameData.ExpLevel);
         GameData.UniversalExpMultiplier = floor1 - (GameData.DecayPerLevel * floor0);*/
 
-        if (InputUtils.KeyJustPressed(Keys.I)) {
+        var debugShellKeyPressed = InputUtils.KeyJustPressed(Keys.I);
+        if (LocalControlPolicy.ShouldRunLegacyDebugShellShortcut(
+            DebugManager.DebuggingEnabled,
+            DebugManager.DebugLevel,
+            Client.IsConnected(),
+            LocalGameSession.Current.IsLocalCoop,
+            LevelEditorUI.IsActive,
+            debugShellKeyPressed)) {
             new Shell(new Vector2(0, 100), -Vector2.UnitY * 2, ShellID.Standard, null);
             new Shell(new Vector2(MouseUtils.Test.X * 10, -100), Vector2.UnitY * 2, ShellID.Standard, null);
         }

--- a/GameContent/Globals/CameraGlobals.cs
+++ b/GameContent/Globals/CameraGlobals.cs
@@ -15,6 +15,8 @@ using System;
 
 namespace TanksRebirth.GameContent.Globals;
 
+public readonly record struct PovCameraState(Matrix View, Matrix Projection, Vector3 Position);
+
 public static class CameraGlobals {
 
     public static bool IsUsingFirstPresonCamera => MatrixUtils.AreMatricesEqual(GameProjection, RebirthFreecam.Projection, 0.1f);
@@ -66,6 +68,24 @@ public static class CameraGlobals {
 
     public static Matrix GameView;
     public static Matrix GameProjection;
+
+    public static PovCameraState CreatePovCamera(Vector2 tankPosition, float turretRotation, float aspectRatio) =>
+        CreatePovCamera(tankPosition.ExpandZ(), turretRotation, aspectRatio);
+
+    public static PovCameraState CreatePovCamera(Vector3 cameraPosition, float turretRotation, float aspectRatio) {
+        if (!float.IsFinite(aspectRatio) || aspectRatio <= 0f)
+            throw new ArgumentOutOfRangeException(nameof(aspectRatio), aspectRatio, "POV camera aspect ratio must be positive and finite.");
+
+        var cameraRotation = -turretRotation;
+        var view = Matrix.CreateLookAt(
+            cameraPosition,
+            cameraPosition + new Vector2(0, 20).Rotate(cameraRotation).ExpandZ(),
+            Vector3.Up
+        ) * Matrix.CreateScale(AddativeZoom) * Matrix.CreateTranslation(0, -20, 0);
+        var projection = Matrix.CreatePerspectiveFieldOfView(
+            MathHelper.ToRadians(90), aspectRatio, 0.1f, 10000f);
+        return new PovCameraState(view, projection, cameraPosition);
+    }
 
     public static void Initialize(GraphicsDevice device) {
         RebirthFreecam = new(device);

--- a/GameContent/Systems/AI/AITank.cs
+++ b/GameContent/Systems/AI/AITank.cs
@@ -322,13 +322,18 @@ public partial class AITank : Tank {
         // pretty sure != null isn't necessary because if Source is null it can't convert
         // it knows the owner is not me but increments my kill count anyway
         if (context.Source is PlayerTank p) {
-            var myId = NetPlay.GetMyClientId();
+            if (Client.IsConnected()) {
+                var myId = NetPlay.GetMyClientId();
 
-            bool isMe = p.PlayerId == myId;
-            if (isMe)
-                PlayerTank.KillCounts[myId]++;
+                bool isMe = p.PlayerId == myId;
+                if (isMe)
+                    PlayerTank.KillCounts[myId]++;
+            }
+            else {
+                PlayerTank.KillCounts[p.PlayerId]++;
+            }
         }
-        // hardcoded for now until local multiplayer exists
+        // Preserve legacy credit for offline environmental or AI-owned kills, where no local player owns the damage.
         else if (!Client.IsConnected()) {
             PlayerTank.KillCounts[0]++;
 

--- a/GameContent/Systems/Campaign.cs
+++ b/GameContent/Systems/Campaign.cs
@@ -22,6 +22,7 @@ using TanksRebirth.Net;
 using TanksRebirth.GameContent.UI.LevelEditor;
 using TanksRebirth.GameContent.Systems.AI;
 using TanksRebirth.GameContent.Systems.TankSystem;
+using TanksRebirth.GameContent.Systems.LocalCoop;
 
 namespace TanksRebirth.GameContent.Systems;
 
@@ -44,6 +45,7 @@ public class Campaign
     public Mission CurrentMission { get; private set; }
     public Mission LoadedMission { get; private set; }
     public int CurrentMissionId { get; private set; }
+    public IReadOnlyList<int> AvailableActiveLocalPlayerIds { get; private set; } = Array.Empty<int>();
 
     /// <summary>The meta-data for this campaign.</summary>
     public CampaignMetaData MetaData;
@@ -116,6 +118,9 @@ public class Campaign
         SceneManager.CleanupScene();
         const int roundingFactor = 5;
         int numPlayers = 0;
+        var applyLocalCampaignRules = LocalCampaignRules.ShouldApplyToMission(Client.IsConnected(), LevelEditorUI.IsActive);
+        var availableActiveLocalTemplateIds = new List<int>();
+        AvailableActiveLocalPlayerIds = Array.Empty<int>();
         for (int i = 0; i < LoadedMission.Tanks.Length; i++) {
             var template = LoadedMission.Tanks[i];
 
@@ -164,6 +169,33 @@ public class Campaign
                 }
             }
             else {
+                if (applyLocalCampaignRules) {
+                    if (LocalCampaignRules.ShouldUseAiCompanionTemplate(
+                        LocalGameSession.Current,
+                        Difficulties.Types["AiCompanion"],
+                        template.PlayerType)) {
+                        var randomTier = AITank.PickRandomTier();
+                        var companion = new AITank(randomTier) {
+                            Position = template.Position,
+                            Team = template.Team,
+                            ChassisRotation = MathF.Round(template.Rotation, roundingFactor),
+                            DesiredChassisRotation = MathF.Round(template.Rotation, roundingFactor),
+                            TurretRotation = MathF.Round(-template.Rotation, roundingFactor),
+                            IsDestroyed = false,
+                        };
+                        companion.Physics.Position = template.Position / Tank.UNITS_PER_METER;
+                        continue;
+                    }
+
+                    if (!LocalCampaignRules.ShouldSpawnPlayer(
+                        LocalGameSession.Current,
+                        template.PlayerType,
+                        PlayerTank.Lives[template.PlayerType]))
+                        continue;
+
+                    availableActiveLocalTemplateIds.Add(template.PlayerType);
+                }
+
                 numPlayers++;
                 if ((Client.IsConnected() && numPlayers <= Server.CurrentClientCount) || !Client.IsConnected()) {
                     var tank = template.GetPlayerTank();
@@ -175,22 +207,32 @@ public class Campaign
                     tank.IsDestroyed = false;
                     tank.Team = template.Team;
 
-                    if (tank.PlayerId <= Server.CurrentClientCount) {
-                        if (!LevelEditorUI.IsActive) {
-                            if (NetPlay.IsClientMatched(tank.PlayerId)) {
-                                PlayerTank.MyTeam = tank.Team;
-                                PlayerTank.MyTankType = tank.PlayerType;
+                    if (Client.IsConnected()) {
+                        if (tank.PlayerId <= Server.CurrentClientCount) {
+                            if (!LevelEditorUI.IsActive) {
+                                if (NetPlay.IsClientMatched(tank.PlayerId)) {
+                                    PlayerTank.MyTeam = tank.Team;
+                                    PlayerTank.MyTankType = tank.PlayerType;
+                                }
                             }
                         }
-                    }
-                    else if (!LevelEditorUI.IsActive)
-                        tank.Remove(true);
-                    if (Client.IsConnected()) {
+                        else if (!LevelEditorUI.IsActive)
+                            tank.Remove(true);
                         if (PlayerTank.Lives[tank.PlayerId] <= 0)
                             tank.Remove(true);
                     }
+                    else {
+                        if (!LevelEditorUI.IsActive && tank.PlayerId == PlayerID.Blue) {
+                            PlayerTank.MyTeam = tank.Team;
+                            PlayerTank.MyTankType = tank.PlayerType;
+                        }
+                        if (!LevelEditorUI.IsActive
+                            && LocalCampaignRules.ShouldUseLives(LocalGameSession.Current)
+                            && PlayerTank.Lives[tank.PlayerId] <= 0)
+                            tank.Remove(true);
+                    }
                     // TODO: note to self, this code above is what causes the skill issue.
-                    if (Difficulties.Types["AiCompanion"] && 
+                    if ((Client.IsConnected() || (LevelEditorUI.IsActive && !LocalGameSession.Current.IsLocalCoop)) && Difficulties.Types["AiCompanion"] &&
                         (template.PlayerType == Server.CurrentClientCount + PlayerID.Red || 
                         (Server.CurrentClientCount == 4 && template.PlayerType == PlayerID.Yellow))) {
                         var randomTier = AITank.PickRandomTier();
@@ -214,6 +256,15 @@ public class Campaign
                     }
                 }
             }
+        }
+
+        if (applyLocalCampaignRules) {
+            AvailableActiveLocalPlayerIds = LocalCampaignRules.AvailableActivePlayerIds(
+                LocalGameSession.Current,
+                availableActiveLocalTemplateIds);
+            var templateError = LocalCampaignRules.GetTemplateValidationError(AvailableActiveLocalPlayerIds, LocalGameSession.Current);
+            if (templateError is not null)
+                ChatSystem.SendMessage(templateError, Color.Red);
         }
 
         for (int b = 0; b < LoadedMission.Blocks.Length; b++) {
@@ -326,7 +377,7 @@ public class Campaign
     public static Campaign Load(string fileName) {
         Campaign campaign = new();
 
-        using var reader = new BinaryReader(File.Open(Path.Combine(TankGame.SaveDirectory, fileName), FileMode.Open, FileAccess.Read));
+        using var reader = new BinaryReader(File.Open(ResolveLoadPath(TankGame.SaveDirectory, fileName), FileMode.Open, FileAccess.Read));
 
         var header = reader.ReadBytes(4);
         if (!header.SequenceEqual(LevelEditorUI.LevelFileHeader))
@@ -388,6 +439,26 @@ public class Campaign
         }
         return campaign;
     }
+
+    public static string ResolveLoadPath(string saveDirectory, string fileName) {
+        if (Path.IsPathRooted(fileName))
+            return fileName;
+
+        var normalizedSaveDirectory = Path.TrimEndingDirectorySeparator(NormalizePathSeparators(saveDirectory));
+        var normalizedFileName = NormalizePathSeparators(fileName);
+        var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        if (normalizedFileName.Equals(normalizedSaveDirectory, comparison) ||
+            normalizedFileName.StartsWith(normalizedSaveDirectory + Path.DirectorySeparatorChar, comparison))
+            return fileName;
+
+        return Path.Combine(saveDirectory, fileName);
+    }
+
+    private static string NormalizePathSeparators(string path)
+        => Path.AltDirectorySeparatorChar == Path.DirectorySeparatorChar
+            ? path
+            : path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+
     /// <summary>The metadata for any given campaign.</summary>
     public struct CampaignMetaData
     {

--- a/GameContent/Systems/IntermissionHandler.cs
+++ b/GameContent/Systems/IntermissionHandler.cs
@@ -8,6 +8,7 @@ using TanksRebirth.GameContent.ID;
 using TanksRebirth.GameContent.RebirthUtils;
 using TanksRebirth.GameContent.Speedrunning;
 using TanksRebirth.GameContent.Systems.TankSystem;
+using TanksRebirth.GameContent.Systems.LocalCoop;
 using TanksRebirth.GameContent.UI;
 using TanksRebirth.GameContent.UI.LevelEditor;
 using TanksRebirth.GameContent.UI.MainMenu;
@@ -160,7 +161,33 @@ public static class IntermissionHandler {
 
         var nothingAnymore = NothingCanHappenAnymore(CampaignGlobals.LoadedCampaign.CurrentMission, out var finalTeam);
         var myTank = GameHandler.AllPlayerTanks[NetPlay.GetMyClientId()];
-        bool victory = myTank is null ? true : myTank.Team != TeamID.NoTeam && myTank.Team == finalTeam;
+        bool victory;
+        if (Client.IsConnected())
+            victory = myTank is null ? true : myTank.Team != TeamID.NoTeam && myTank.Team == finalTeam;
+        else {
+            var localPlayerTeams = GameHandler.AllPlayerTanks
+                .Select(tank => tank?.Team ?? TeamID.NoTeam)
+                .ToArray();
+            var localPlayerAlive = GameHandler.AllPlayerTanks
+                .Select(tank => tank is not null && !tank.IsDestroyed)
+                .ToArray();
+            victory = LocalCampaignRules.IsLocalVictory(
+                LocalGameSession.Current,
+                localPlayerTeams,
+                localPlayerAlive,
+                finalTeam,
+                TeamID.NoTeam);
+
+            if (LocalGameSession.Current.IsLocalCoop
+                && LocalCampaignRules.ShouldEndAsGameOver(
+                    LocalGameSession.Current,
+                    CampaignGlobals.LoadedCampaign.AvailableActiveLocalPlayerIds,
+                    localPlayerAlive,
+                    PlayerTank.Lives)) {
+                PrepareIntermission(victory: false);
+                return;
+            }
+        }
 
         if (nothingAnymore) {
             PrepareIntermission(victory);
@@ -175,11 +202,18 @@ public static class IntermissionHandler {
             int restartTime;
             MissionEndContext endContext;
 
-            IntermissionSystem.InitializeCountdowns(isExtraLifeMission && victory);
+            var useBonusLifeSequence = Client.IsConnected()
+                ? isExtraLifeMission && victory
+                : LocalCampaignRules.ShouldUseBonusLifeSequence(LocalGameSession.Current, isExtraLifeMission, victory);
+
+            IntermissionSystem.ShouldDrawBanner = !useBonusLifeSequence;
+            if (!useBonusLifeSequence)
+                IntermissionSystem.ShouldDrawBonusBanner = false;
+            IntermissionSystem.InitializeCountdowns(useBonusLifeSequence);
             if (victory) {
                 restartTime = DEF_INTERMISSION_TIME;
 
-                if (isExtraLifeMission) {
+                if (useBonusLifeSequence) {
                     restartTime += DEF_PLUSLIFE_TIME;
                     IntermissionSystem.ShouldDrawBanner = false;
                 }
@@ -203,24 +237,41 @@ public static class IntermissionHandler {
                     }
                 }*/
 
-                // we want to move on anyway even if one player 'lost' and another 'won' so other players aren't held back while others advance (desync alert!!)
-                var allPlayersDead = !GameHandler.AllPlayerTanks.Any(tnk => tnk != null && !tnk.IsDestroyed);
+                bool allPlayersDead;
+                bool everyoneLostAllLives;
+                if (Client.IsConnected()) {
+                    // we want to move on anyway if one network player lost and another won, so clients are not held back.
+                    allPlayersDead = !GameHandler.AllPlayerTanks.Any(tnk => tnk != null && !tnk.IsDestroyed);
 
-                // assume true, but set to false later if any player has lives remaining
-                bool everyoneLostAllLives = true;
-                if (allPlayersDead) {
-                    // networking is *consistently* behind the host here
+                    // assume true, but set to false later if any player has lives remaining
+                    everyoneLostAllLives = true;
+                    if (allPlayersDead) {
+                        // networking is *consistently* behind the host here
 
-                    for (int i = 0; i < GameHandler.AllPlayerTanks.Length; i++) {
-                        var tank = GameHandler.AllPlayerTanks[i];
-                        if (tank is null) continue;
-                        var lives = PlayerTank.Lives[i];
-                        var livesCountLocal = tank.IsDestroyed ? lives - 1 : lives;
+                        for (int i = 0; i < GameHandler.AllPlayerTanks.Length; i++) {
+                            var tank = GameHandler.AllPlayerTanks[i];
+                            if (tank is null) continue;
+                            var lives = PlayerTank.Lives[i];
+                            var livesCountLocal = tank.IsDestroyed ? lives - 1 : lives;
 
-                        // if any player has any lives remaining, the campaign isn't over
-                        if (livesCountLocal > 0)
-                            everyoneLostAllLives = false;
+                            // if any player has any lives remaining, the campaign isn't over
+                            if (livesCountLocal > 0)
+                                everyoneLostAllLives = false;
+                        }
                     }
+                }
+                else {
+                    var availablePlayerIds = CampaignGlobals.LoadedCampaign.AvailableActiveLocalPlayerIds;
+                    var playerAlive = GameHandler.AllPlayerTanks.Select(tank => tank is not null && !tank.IsDestroyed).ToArray();
+                    allPlayersDead = availablePlayerIds.All(playerId => {
+                        var tank = GameHandler.AllPlayerTanks[playerId];
+                        return tank is null || tank.IsDestroyed;
+                    });
+                    everyoneLostAllLives = LocalCampaignRules.ShouldEndAsGameOver(
+                        LocalGameSession.Current,
+                        availablePlayerIds,
+                        playerAlive,
+                        PlayerTank.Lives);
                 }
 
                 if (allPlayersDead) {
@@ -233,10 +284,11 @@ public static class IntermissionHandler {
                     endContext = MissionEndContext.Win;
 
                 // hardcode hell 2: electric boogaloo
-                if (Difficulties.Types["InfiniteLives"])
+                if (Difficulties.Types["InfiniteLives"]
+                    && (Client.IsConnected() || LocalCampaignRules.ShouldUseLives(LocalGameSession.Current)))
                     endContext = MissionEndContext.Lose;
             }
-            CampaignGlobals.MissionEndEvent_Invoke(restartTime, endContext, isExtraLifeMission);
+            CampaignGlobals.MissionEndEvent_Invoke(restartTime, endContext, useBonusLifeSequence);
         }
     }
     /// <summary>This marks the beginning of the player seeing all of the tanks on the map, before the round begins.</summary>

--- a/GameContent/Systems/IntermissionSystem.cs
+++ b/GameContent/Systems/IntermissionSystem.cs
@@ -16,6 +16,7 @@ using System.Runtime.Intrinsics.X86;
 using TanksRebirth.GameContent.UI.MainMenu;
 using TanksRebirth.Enums;
 using TanksRebirth.Graphics.Shaders;
+using TanksRebirth.GameContent.Systems.LocalCoop;
 
 namespace TanksRebirth.GameContent.Systems;
 #pragma warning disable
@@ -383,10 +384,11 @@ public static class IntermissionSystem {
 
         // draw player graphics & life remaining
         var tnk2d = GameResources.GetGameResource<Texture2D>("Assets/textures/ui/playertank2d");
-        var count = Server.CurrentClientCount > 0 ? Server.CurrentClientCount : Server.CurrentClientCount + 1;
+        var count = Client.IsConnected() ? Server.CurrentClientCount : LocalGameSession.Current.PlayerCount;
+        var shouldDrawLives = Client.IsConnected() || LocalCampaignRules.ShouldUseLives(LocalGameSession.Current);
 
         for (int i = 0; i < count; i++) {
-            var name = Client.IsConnected() ? Server.ConnectedClients[i].Name : string.Empty;
+            var name = Client.IsConnected() ? Server.ConnectedClients[i].Name : $"P{i + 1}";
 
             var brightPlayerColor = ColorUtils.ChangeColorBrightness(PlayerID.PlayerTankColors[i], 0.85f);
             var brighterPlayerColor = ColorUtils.ChangeColorBrightness(PlayerID.PlayerTankColors[i], 0.25f);
@@ -395,17 +397,19 @@ public static class IntermissionSystem {
 
             var lerpedColor = Color.Lerp(brightPlayerColor, GradientTopColor, brightness);
 
-            var lifeText = $"×  {PlayerTank.Lives[i]}";
-            DrawUtils.DrawStringWithBorderAndShadow(spriteBatch, FontGlobals.RebirthFontLarge,
-                pos + new Vector2(75, -25).ToResolution(),
-                Vector2.One,
-                lifeText,
-                lerpedColor,
-                // hacky or not?
-                PlayerID.PlayerTankColors[i],
-                Vector2.One.ToResolution() * (ShouldDrawBanner ? Vector2.One : BonusLifeAnimator.CurrentScale),
-                1f,
-                Anchor.Center, shadowDistScale: 1.5f, shadowAlpha: 0.5f, borderThickness: 1f);
+            if (shouldDrawLives) {
+                var lifeText = $"×  {PlayerTank.Lives[i]}";
+                DrawUtils.DrawStringWithBorderAndShadow(spriteBatch, FontGlobals.RebirthFontLarge,
+                    pos + new Vector2(75, -25).ToResolution(),
+                    Vector2.One,
+                    lifeText,
+                    lerpedColor,
+                    // hacky or not?
+                    PlayerID.PlayerTankColors[i],
+                    Vector2.One.ToResolution() * (ShouldDrawBanner ? Vector2.One : BonusLifeAnimator.CurrentScale),
+                    1f,
+                    Anchor.Center, shadowDistScale: 1.5f, shadowAlpha: 0.5f, borderThickness: 1f);
+            }
 
             DrawUtils.DrawStringWithShadow(spriteBatch, FontGlobals.RebirthFontLarge,
                 pos - new Vector2(0, 75).ToResolution(),
@@ -415,7 +419,8 @@ public static class IntermissionSystem {
                 new Vector2(0.3f).ToResolution(),
                 1f,
                 Anchor.Center, shadowDistScale: 1.5f, shadowAlpha: 0.5f);
-            DrawUtils.DrawTextureWithShadow(spriteBatch, tnk2d, pos - new Vector2(130, 0).ToResolution(), Vector2.One,
+            var tankOffset = shouldDrawLives ? new Vector2(130, 0).ToResolution() : Vector2.Zero;
+            DrawUtils.DrawTextureWithShadow(spriteBatch, tnk2d, pos - tankOffset, Vector2.One,
                 brighterPlayerColor, Vector2.One * 1.5f, 1f, Anchor.Center,
                 shadowDistScale: 1f, shadowAlpha: 0.5f);
         }

--- a/GameContent/Systems/LocalCoop/LocalCampaignRules.cs
+++ b/GameContent/Systems/LocalCoop/LocalCampaignRules.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TanksRebirth.GameContent.Systems.LocalCoop;
+
+public static class LocalCampaignRules {
+    public static int[] ActivePlayerIds(LocalSession session) {
+        ArgumentNullException.ThrowIfNull(session);
+        return Enumerable.Range(0, session.PlayerCount).ToArray();
+    }
+
+    public static bool ShouldUseLives(LocalSession session) {
+        ArgumentNullException.ThrowIfNull(session);
+        return !session.IsLocalCoop;
+    }
+
+    public static bool ShouldSpawnPlayer(LocalSession session, int playerId, int livesRemaining) {
+        ArgumentNullException.ThrowIfNull(session);
+        return session.IsActivePlayer(playerId) && (!ShouldUseLives(session) || livesRemaining > 0);
+    }
+
+    public static bool ShouldUseAiCompanionTemplate(LocalSession session, bool aiCompanionEnabled, int playerId) {
+        ArgumentNullException.ThrowIfNull(session);
+        const int redPlayerId = 1;
+        return aiCompanionEnabled && !session.IsLocalCoop && playerId == redPlayerId;
+    }
+
+    public static int[] AvailableActivePlayerIds(LocalSession session, IEnumerable<int> templatePlayerIds) {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(templatePlayerIds);
+        var availablePlayerIds = new List<int>();
+        var seenPlayerIds = new HashSet<int>();
+        foreach (var playerId in templatePlayerIds) {
+            if (session.IsActivePlayer(playerId) && seenPlayerIds.Add(playerId))
+                availablePlayerIds.Add(playerId);
+        }
+
+        return availablePlayerIds.ToArray();
+    }
+
+    public static bool ShouldApplyToMission(bool clientConnected, bool levelEditorActive)
+        => !clientConnected && !levelEditorActive;
+
+    public static void ChangeLife(int[] lives, LocalSession session, int playerId, int delta) {
+        ArgumentNullException.ThrowIfNull(lives);
+        ArgumentNullException.ThrowIfNull(session);
+        if (playerId < 0 || playerId >= lives.Length)
+            throw new ArgumentOutOfRangeException(nameof(playerId));
+
+        if (ShouldUseLives(session))
+            lives[playerId] += delta;
+    }
+
+    public static void ChangeLivesForActivePlayers(int[] lives, LocalSession session, int delta) {
+        ArgumentNullException.ThrowIfNull(lives);
+        ArgumentNullException.ThrowIfNull(session);
+        if (lives.Length < session.PlayerCount)
+            throw new ArgumentOutOfRangeException(nameof(lives), "Lives array must contain every active local player.");
+
+        foreach (var playerId in ActivePlayerIds(session))
+            ChangeLife(lives, session, playerId, delta);
+    }
+
+    public static bool CanTeamContinue(int[] lives, IReadOnlyCollection<int> availablePlayerIds) {
+        ArgumentNullException.ThrowIfNull(lives);
+        ArgumentNullException.ThrowIfNull(availablePlayerIds);
+        foreach (var playerId in availablePlayerIds) {
+            if (playerId < 0)
+                throw new ArgumentOutOfRangeException(nameof(availablePlayerIds));
+            if (playerId >= lives.Length)
+                throw new ArgumentOutOfRangeException(nameof(lives), "Lives array must contain every available local player.");
+        }
+
+        return availablePlayerIds.Any(playerId => lives[playerId] > 0);
+    }
+
+    public static bool ShouldEndAsGameOver(
+        LocalSession session,
+        IReadOnlyCollection<int> availablePlayerIds,
+        IReadOnlyList<bool> playerAlive,
+        IReadOnlyList<int> lives) {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(availablePlayerIds);
+        ArgumentNullException.ThrowIfNull(playerAlive);
+        ArgumentNullException.ThrowIfNull(lives);
+
+        if (availablePlayerIds.Count == 0)
+            return true;
+
+        foreach (var playerId in availablePlayerIds) {
+            if (playerId < 0 || playerId >= playerAlive.Count)
+                throw new ArgumentOutOfRangeException(nameof(playerAlive), "Alive state must contain every available local player.");
+            if (playerId >= lives.Count)
+                throw new ArgumentOutOfRangeException(nameof(lives), "Lives must contain every available local player.");
+        }
+
+        var allAvailablePlayersDead = availablePlayerIds.All(playerId => !playerAlive[playerId]);
+
+        if (!allAvailablePlayersDead)
+            return false;
+
+        return session.IsLocalCoop || !availablePlayerIds.Any(playerId => lives[playerId] > 0);
+    }
+
+    public static bool ShouldUseBonusLifeSequence(LocalSession session, bool missionGrantsBonusLife, bool victory) {
+        ArgumentNullException.ThrowIfNull(session);
+        return ShouldUseLives(session) && missionGrantsBonusLife && victory;
+    }
+
+    public static bool IsLocalVictory(
+        LocalSession session,
+        IReadOnlyList<int> playerTeams,
+        IReadOnlyList<bool> playerAlive,
+        int finalTeam,
+        int noTeam) {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(playerTeams);
+        ArgumentNullException.ThrowIfNull(playerAlive);
+        if (playerTeams.Count < session.PlayerCount)
+            throw new ArgumentOutOfRangeException(nameof(playerTeams), "Team collection must contain every active local player.");
+        if (playerAlive.Count < session.PlayerCount)
+            throw new ArgumentOutOfRangeException(nameof(playerAlive), "Alive collection must contain every active local player.");
+
+        if (!session.IsLocalCoop)
+            return playerTeams[0] != noTeam && playerTeams[0] == finalTeam;
+
+        return ActivePlayerIds(session).Any(playerId =>
+            playerAlive[playerId] &&
+            playerTeams[playerId] != noTeam &&
+            playerTeams[playerId] == finalTeam);
+    }
+
+    public static string? GetTemplateValidationError(IReadOnlyCollection<int> availablePlayerIds, LocalSession session) {
+        ArgumentNullException.ThrowIfNull(availablePlayerIds);
+        ArgumentNullException.ThrowIfNull(session);
+        if (availablePlayerIds.Count == 0)
+            return "No active player templates are available for the current local session.";
+
+        if (availablePlayerIds.Count < session.PlayerCount)
+            return $"The current local session needs {session.PlayerCount} active player templates, but this mission provides {availablePlayerIds.Count}.";
+
+        return null;
+    }
+}

--- a/GameContent/Systems/LocalCoop/LocalControlPolicy.cs
+++ b/GameContent/Systems/LocalCoop/LocalControlPolicy.cs
@@ -26,6 +26,12 @@ public static class LocalControlPolicy {
     public static float DirectionalTurretRotation(Vector2 aim) =>
         -aim.ToRotation() + MathHelper.PiOver2;
 
+    public static Vector2 ApplyPovMovement(Vector2 movement, float turretRotation) =>
+        movement.Rotate(-turretRotation + MathHelper.Pi);
+
+    public static float ApplyPovYaw(float currentRotation, float horizontalInput, float rotationAmount) =>
+        currentRotation - horizontalInput * rotationAmount;
+
     public static bool CanUseLocalWeapon(
         bool gameplayInputAllowed,
         bool stationary,

--- a/GameContent/Systems/LocalCoop/LocalControlPolicy.cs
+++ b/GameContent/Systems/LocalCoop/LocalControlPolicy.cs
@@ -1,0 +1,43 @@
+using Microsoft.Xna.Framework;
+using TanksRebirth.Internals.Common.Utilities;
+
+namespace TanksRebirth.GameContent.Systems.LocalCoop;
+
+public static class LocalControlPolicy {
+    private const int GeneralDebugLevel = 0;
+
+    public static bool ShouldRunLegacyDebugShellShortcut(
+        bool debuggingEnabled,
+        int debugLevel,
+        bool clientConnected,
+        bool localCoop,
+        bool levelEditorActive,
+        bool keyJustPressed) =>
+        debuggingEnabled
+        && debugLevel == GeneralDebugLevel
+        && !clientConnected
+        && !localCoop
+        && !levelEditorActive
+        && keyJustPressed;
+
+    public static bool CanControlOffline(bool networkConnected, LocalSession session, int playerId) =>
+        !networkConnected && session.IsActivePlayer(playerId);
+
+    public static float DirectionalTurretRotation(Vector2 aim) =>
+        -aim.ToRotation() + MathHelper.PiOver2;
+
+    public static bool CanUseLocalWeapon(
+        bool gameplayInputAllowed,
+        bool stationary,
+        float shootStun,
+        float mineStun,
+        float cooldown,
+        long ownedCount,
+        long capacity) =>
+        gameplayInputAllowed
+        && !stationary
+        && shootStun <= 0
+        && mineStun <= 0
+        && cooldown <= 0
+        && ownedCount < capacity;
+}

--- a/GameContent/Systems/LocalCoop/LocalCoopPovPolicy.cs
+++ b/GameContent/Systems/LocalCoop/LocalCoopPovPolicy.cs
@@ -35,6 +35,18 @@ public static class LocalCoopPovPolicy {
     public static bool ShouldRecreateTarget(Point currentSize, bool disposed, Point desiredSize) =>
         disposed || currentSize != desiredSize;
 
+    public static string BuildHudText(int playerId, int kills, int enemies, bool down, int spectatingPlayerId) {
+        if (playerId is < 0 or > 1)
+            throw new ArgumentOutOfRangeException(nameof(playerId), playerId, "Only local players 0 and 1 are supported.");
+        if (spectatingPlayerId is < 0 or > 1)
+            throw new ArgumentOutOfRangeException(nameof(spectatingPlayerId), spectatingPlayerId, "Only local players 0 and 1 are supported.");
+
+        var text = $"P{playerId + 1}   K {kills}   ENEMIES {enemies}";
+        if (down)
+            text += $"   DOWN - SPECTATING P{spectatingPlayerId + 1}";
+        return text;
+    }
+
     public static int ResolveCameraPlayerId(
         int requestedPlayerId,
         bool playerOneAvailable,

--- a/GameContent/Systems/LocalCoop/LocalCoopPovPolicy.cs
+++ b/GameContent/Systems/LocalCoop/LocalCoopPovPolicy.cs
@@ -1,0 +1,61 @@
+using System;
+using Microsoft.Xna.Framework;
+
+namespace TanksRebirth.GameContent.Systems.LocalCoop;
+
+public readonly record struct LocalCoopPovLayout(Rectangle PlayerOne, Rectangle PlayerTwo);
+
+public static class LocalCoopPovPolicy {
+    public static bool ShouldUseSplitScreen(
+        bool localCoop,
+        bool pov,
+        bool mainMenu,
+        bool levelEditor,
+        bool connected) =>
+        localCoop && pov && !mainMenu && !levelEditor && !connected;
+
+    public static LocalCoopPovLayout CreateHorizontalLayout(int width, int height) {
+        if (width <= 0)
+            throw new ArgumentOutOfRangeException(nameof(width), width, "Split-screen width must be positive.");
+        if (height < 2)
+            throw new ArgumentOutOfRangeException(nameof(height), height, "Split-screen height must fit both players.");
+
+        var playerOneHeight = height / 2;
+        return new LocalCoopPovLayout(
+            new Rectangle(0, 0, width, playerOneHeight),
+            new Rectangle(0, playerOneHeight, width, height - playerOneHeight));
+    }
+
+    public static Point TargetSize(Rectangle destination) {
+        if (destination.Width <= 0 || destination.Height <= 0)
+            throw new ArgumentOutOfRangeException(nameof(destination), destination, "Render destination must have positive dimensions.");
+        return destination.Size;
+    }
+
+    public static int ResolveCameraPlayerId(
+        int requestedPlayerId,
+        bool playerOneAvailable,
+        bool playerOneDestroyed,
+        bool playerTwoAvailable,
+        bool playerTwoDestroyed) {
+        if (requestedPlayerId is < 0 or > 1)
+            throw new ArgumentOutOfRangeException(nameof(requestedPlayerId), requestedPlayerId, "Only local players 0 and 1 are supported.");
+
+        var requestedAvailable = requestedPlayerId == 0 ? playerOneAvailable : playerTwoAvailable;
+        var requestedDestroyed = requestedPlayerId == 0 ? playerOneDestroyed : playerTwoDestroyed;
+        if (requestedAvailable && !requestedDestroyed)
+            return requestedPlayerId;
+
+        var otherPlayerId = 1 - requestedPlayerId;
+        var otherAvailable = otherPlayerId == 0 ? playerOneAvailable : playerTwoAvailable;
+        var otherDestroyed = otherPlayerId == 0 ? playerOneDestroyed : playerTwoDestroyed;
+        if (otherAvailable && !otherDestroyed)
+            return otherPlayerId;
+
+        if (requestedAvailable)
+            return requestedPlayerId;
+        if (otherAvailable)
+            return otherPlayerId;
+        return -1;
+    }
+}

--- a/GameContent/Systems/LocalCoop/LocalCoopPovPolicy.cs
+++ b/GameContent/Systems/LocalCoop/LocalCoopPovPolicy.cs
@@ -32,6 +32,9 @@ public static class LocalCoopPovPolicy {
         return destination.Size;
     }
 
+    public static bool ShouldRecreateTarget(Point currentSize, bool disposed, Point desiredSize) =>
+        disposed || currentSize != desiredSize;
+
     public static int ResolveCameraPlayerId(
         int requestedPlayerId,
         bool playerOneAvailable,

--- a/GameContent/Systems/LocalCoop/LocalCoopPovRuntime.cs
+++ b/GameContent/Systems/LocalCoop/LocalCoopPovRuntime.cs
@@ -1,0 +1,38 @@
+using TanksRebirth.GameContent.Systems.TankSystem;
+using TanksRebirth.GameContent.UI.LevelEditor;
+using TanksRebirth.GameContent.UI.MainMenu;
+using TanksRebirth.Net;
+
+namespace TanksRebirth.GameContent.Systems.LocalCoop;
+
+public static class LocalCoopPovRuntime {
+    public static bool IsActive => LocalCoopPovPolicy.ShouldUseSplitScreen(
+        LocalGameSession.Current.IsLocalCoop,
+        Difficulties.Types["POV"],
+        MainMenuUI.IsActive,
+        LevelEditorUI.IsActive,
+        Client.IsConnected());
+
+    public static PlayerTank? ResolveCameraTank(int requestedPlayerId) {
+        var playerOne = GameHandler.AllPlayerTanks[0];
+        var playerTwo = GameHandler.AllPlayerTanks[1];
+        var resolvedPlayerId = LocalCoopPovPolicy.ResolveCameraPlayerId(
+            requestedPlayerId,
+            playerOne is not null,
+            playerOne?.IsDestroyed ?? false,
+            playerTwo is not null,
+            playerTwo?.IsDestroyed ?? false);
+        return resolvedPlayerId switch {
+            0 => playerOne,
+            1 => playerTwo,
+            _ => null
+        };
+    }
+
+    public static bool IsPlayerDown(int playerId) {
+        if (playerId is < 0 or > 1)
+            return true;
+        var tank = GameHandler.AllPlayerTanks[playerId];
+        return tank is null || tank.IsDestroyed;
+    }
+}

--- a/GameContent/Systems/LocalCoop/LocalSession.cs
+++ b/GameContent/Systems/LocalCoop/LocalSession.cs
@@ -1,0 +1,20 @@
+namespace TanksRebirth.GameContent.Systems.LocalCoop;
+
+public enum LocalPlayMode {
+    SinglePlayer,
+    LocalCoop
+}
+
+public sealed class LocalSession {
+    public LocalPlayMode Mode { get; private set; } = LocalPlayMode.SinglePlayer;
+    public int PlayerCount => Mode == LocalPlayMode.LocalCoop ? 2 : 1;
+    public bool IsLocalCoop => Mode == LocalPlayMode.LocalCoop;
+
+    public void StartSinglePlayer() => Mode = LocalPlayMode.SinglePlayer;
+    public void StartLocalCoop() => Mode = LocalPlayMode.LocalCoop;
+    public bool IsActivePlayer(int playerId) => playerId >= 0 && playerId < PlayerCount;
+}
+
+public static class LocalGameSession {
+    public static LocalSession Current { get; } = new();
+}

--- a/GameContent/Systems/TankSystem/PlayerTank.cs
+++ b/GameContent/Systems/TankSystem/PlayerTank.cs
@@ -294,7 +294,36 @@ public class PlayerTank : Tank {
         }
 
         var frame = LocalPlayerInputRouter.Runtime.GetFrame(PlayerId);
-        if (frame.AimSource == LocalAimSource.Mouse) {
+        var splitScreenPov = LocalCoopPovPolicy.ShouldUseSplitScreen(
+            session.IsLocalCoop,
+            Difficulties.Types["POV"],
+            MainMenuUI.IsActive,
+            LevelEditorUI.IsActive,
+            Client.IsConnected());
+        if (splitScreenPov && frame.AimSource == LocalAimSource.Mouse) {
+            if (!GameUI.Paused && !DebugManager.IsFreecamEnabled) {
+                var screenCenter = new Point(WindowUtils.WindowWidth / 2, WindowUtils.WindowHeight / 4);
+                if (_justCenteredMouse) {
+                    _justCenteredMouse = false;
+                }
+                else {
+                    var deltaX = frame.AimInput.X - screenCenter.X;
+                    TurretRotation = LocalControlPolicy.ApplyPovYaw(
+                        TurretRotation,
+                        deltaX,
+                        1f / 312f.ToResolutionX());
+                    Mouse.SetPosition(screenCenter.X, screenCenter.Y);
+                    _justCenteredMouse = true;
+                }
+            }
+        }
+        else if (splitScreenPov) {
+            TurretRotation = LocalControlPolicy.ApplyPovYaw(
+                TurretRotation,
+                frame.AimInput.X,
+                0.03f * RuntimeData.DeltaTime);
+        }
+        else if (frame.AimSource == LocalAimSource.Mouse) {
             Vector3 mouseWorldPos = MatrixUtils.GetWorldPosition(frame.Aim, -11f);
             TurretRotation = -(new Vector2(mouseWorldPos.X, mouseWorldPos.Z) - Position).ToRotation() + MathHelper.PiOver2;
         }
@@ -311,7 +340,7 @@ public class PlayerTank : Tank {
             playerControl_isBindPressed = false;
 
         if (gameplayInputAllowed && !Properties.Stationary && CurShootStun <= 0 && CurMineStun <= 0)
-            ControlHandle_LocalCoop(frame.Movement);
+            ControlHandle_LocalCoop(frame.Movement, splitScreenPov);
 
         var canLayMine = LocalControlPolicy.CanUseLocalWeapon(
             gameplayInputAllowed,
@@ -447,13 +476,13 @@ public class PlayerTank : Tank {
 
         ApplyKeyboardMovement(DesiredDirection, applyPov: true);
     }
-    private void ControlHandle_LocalCoop(Vector2 movement) {
+    private void ControlHandle_LocalCoop(Vector2 movement, bool applyPov) {
         if (movement != Vector2.Zero) {
             playerControl_isBindPressed = true;
             LastUsedController = false;
         }
 
-        ApplyKeyboardMovement(movement, applyPov: false);
+        ApplyKeyboardMovement(movement, applyPov);
     }
     private void ApplyKeyboardMovement(Vector2 movement, bool applyPov) {
         IsTurning = false;
@@ -461,7 +490,7 @@ public class PlayerTank : Tank {
         DesiredDirection = movement;
 
         if (applyPov && Difficulties.Types["POV"])
-            DesiredDirection = DesiredDirection.Rotate(-TurretRotation + MathHelper.Pi);
+            DesiredDirection = LocalControlPolicy.ApplyPovMovement(DesiredDirection, TurretRotation);
 
         var norm = Vector2.Normalize(DesiredDirection);
 

--- a/GameContent/Systems/TankSystem/PlayerTank.cs
+++ b/GameContent/Systems/TankSystem/PlayerTank.cs
@@ -26,6 +26,7 @@ using TanksRebirth.GameContent.UI.LevelEditor;
 using TanksRebirth.GameContent.Globals.Assets;
 using TanksRebirth.GameContent.Systems.TankSystem;
 using TanksRebirth.GameContent.Systems.AI;
+using TanksRebirth.GameContent.Systems.LocalCoop;
 using TanksRebirth.Internals.Common.Framework.Collisions;
 
 namespace TanksRebirth.GameContent;
@@ -63,6 +64,7 @@ public class PlayerTank : Tank {
     public static GamepadBind PlaceMine = new("Place Mine", Buttons.A);
 
     private bool playerControl_isBindPressed;
+    private bool _localShotPathHeld;
 
     public Vector2 oldPosition;
 
@@ -85,30 +87,33 @@ public class PlayerTank : Tank {
     /// <para>Note that lives are always synced on multiplayer.</para>
     /// </summary>
     public static int[] Lives { get; set; } = new int[Server.MaxClients];
+    public bool ControlledHere => Client.IsConnected()
+        ? NetPlay.IsClientMatched(PlayerId)
+        : LocalGameSession.Current.IsActivePlayer(PlayerId);
 
     /// <summary>In multiplayer, gets the lives of the client that this code is currently being called on.</summary>
     public static int GetMyLives() => Lives[NetPlay.GetMyClientId()];
     /// <summary>
-    /// Adds lives to the player in Single-Player, adds to the lives of all players in Multiplayer.
+    /// Adds lives to the current player online, or to every active local player offline.
     /// </summary>
     /// <param name="num">How many lives to add.</param>
     public static void AddLives(int num) {
         if (Client.IsConnected())
             Lives[NetPlay.GetMyClientId()] += num;
         else
-            for (int i = 0; i < Lives.Length; i++)
-                Lives[i] += num;
+            LocalCampaignRules.ChangeLivesForActivePlayers(Lives, LocalGameSession.Current, num);
     }
     /// <summary>
-    /// Sets the lives of the player in Single-Player, sets the lives of all players in Multiplayer.
+    /// Sets the current player's lives online, or initializes only the active local players offline.
     /// </summary>
     /// <param name="num">How many lives to set the player(s) to.</param>
     public static void SetLives(int num) {
         if (Client.IsConnected())
             Lives[NetPlay.GetMyClientId()] = num;
-        else
+        else {
             for (int i = 0; i < Lives.Length; i++)
-                Lives[i] = num;
+                Lives[i] = LocalGameSession.Current.IsActivePlayer(i) ? num : 0;
+        }
     }
     public void SwapTankTexture(Texture2D texture) => _tankTexture = texture;
     public PlayerTank(int playerType, bool isPlayerModel = true, int copyTier = -1) {
@@ -213,6 +218,12 @@ public class PlayerTank : Tank {
         if (NetPlay.IsClientMatched(PlayerId))
             Client.SyncPlayerTank(this);
 
+        if (!Client.IsConnected() && LocalGameSession.Current.IsLocalCoop) {
+            ProcessLocalCoopInput();
+            oldPosition = Position;
+            return;
+        }
+
         // TODO: optimize?
         ProcessPlayerMouse();
 
@@ -222,7 +233,7 @@ public class PlayerTank : Tank {
         }
 
         if (!Properties.Stationary) {
-            if (NetPlay.IsClientMatched(PlayerId)) {
+            if (ControlledHere) {
                 if (CurShootStun <= 0 && CurMineStun <= 0) {
                     if (LastUsedController)
                         ControlHandle_ConsoleController();
@@ -232,7 +243,7 @@ public class PlayerTank : Tank {
             }
         }
 
-        if (NetPlay.IsClientMatched(PlayerId)) {
+        if (ControlledHere) {
             if (InputUtils.CanDetectClick()) {
                 if (!ChatSystem.ChatBoxHover && !ChatSystem.ActiveHandle && !GameUI.Paused) {
                     Shoot(false);
@@ -243,7 +254,7 @@ public class PlayerTank : Tank {
         oldPosition = Position;
     }
     void ProcessPlayerMouse() {
-        if (NetPlay.IsClientMatched(PlayerId)) {
+        if (ControlledHere) {
             if (!Difficulties.Types["POV"] || LevelEditorUI.IsActive || MainMenuUI.IsActive) {
                 Vector3 mouseWorldPos = MatrixUtils.GetWorldPosition(MouseUtils.MousePosition, -11f);
                 if (!LevelEditorUI.IsActive)
@@ -274,6 +285,55 @@ public class PlayerTank : Tank {
                 }
             }
         }
+    }
+    private void ProcessLocalCoopInput() {
+        var session = LocalGameSession.Current;
+        if (!LocalControlPolicy.CanControlOffline(false, session, PlayerId)) {
+            _localShotPathHeld = false;
+            return;
+        }
+
+        var frame = LocalPlayerInputRouter.Runtime.GetFrame(PlayerId);
+        if (frame.AimSource == LocalAimSource.Mouse) {
+            Vector3 mouseWorldPos = MatrixUtils.GetWorldPosition(frame.Aim, -11f);
+            TurretRotation = -(new Vector2(mouseWorldPos.X, mouseWorldPos.Z) - Position).ToRotation() + MathHelper.PiOver2;
+        }
+        else {
+            TurretRotation = LocalControlPolicy.DirectionalTurretRotation(frame.Aim);
+        }
+
+        var gameplayInputAllowed = CampaignGlobals.InMission
+            && !LevelEditorUI.IsActive
+            && !ChatSystem.ActiveHandle
+            && !GameUI.Paused;
+        _localShotPathHeld = gameplayInputAllowed && frame.ShotPathHeld;
+        if (!gameplayInputAllowed)
+            playerControl_isBindPressed = false;
+
+        if (gameplayInputAllowed && !Properties.Stationary && CurShootStun <= 0 && CurMineStun <= 0)
+            ControlHandle_LocalCoop(frame.Movement);
+
+        var canLayMine = LocalControlPolicy.CanUseLocalWeapon(
+            gameplayInputAllowed,
+            Properties.Stationary,
+            CurShootStun,
+            CurMineStun,
+            CurMineCooldown,
+            OwnedMineCount,
+            Properties.MineLimit);
+        if (frame.MineJustPressed && canLayMine)
+            LayMine();
+
+        var canFire = LocalControlPolicy.CanUseLocalWeapon(
+            gameplayInputAllowed && (frame.AimSource != LocalAimSource.Mouse || !ChatSystem.ChatBoxHover),
+            Properties.Stationary,
+            CurShootStun,
+            CurMineStun,
+            CurShootCooldown,
+            OwnedShellCount,
+            Properties.ShellLimit / Properties.ShellShootCount);
+        if (frame.FireJustPressed && canFire)
+            Shoot(false);
     }
     public override void Remove(bool nullifyMe) {
         if (nullifyMe) {
@@ -364,12 +424,6 @@ public class PlayerTank : Tank {
         if (controlMine.JustPressed)
             LayMine();
 
-        IsTurning = false;
-
-        //var rotationMet = TankRotation > TargetTankRotation - Properties.MaximalTurn && TankRotation < TargetTankRotation + Properties.MaximalTurn;
-
-        ChassisRotation %= MathHelper.Tau;
-
         if (controlDown.IsPressed) {
             playerControl_isBindPressed = true;
             DesiredDirection.Y = 1;
@@ -391,15 +445,28 @@ public class PlayerTank : Tank {
             LastUsedController = false;
         }
 
-        if (Difficulties.Types["POV"])
+        ApplyKeyboardMovement(DesiredDirection, applyPov: true);
+    }
+    private void ControlHandle_LocalCoop(Vector2 movement) {
+        if (movement != Vector2.Zero) {
+            playerControl_isBindPressed = true;
+            LastUsedController = false;
+        }
+
+        ApplyKeyboardMovement(movement, applyPov: false);
+    }
+    private void ApplyKeyboardMovement(Vector2 movement, bool applyPov) {
+        IsTurning = false;
+        ChassisRotation %= MathHelper.Tau;
+        DesiredDirection = movement;
+
+        if (applyPov && Difficulties.Types["POV"])
             DesiredDirection = DesiredDirection.Rotate(-TurretRotation + MathHelper.Pi);
 
         var norm = Vector2.Normalize(DesiredDirection);
 
         DesiredChassisRotation = norm.ToRotation() - MathHelper.PiOver2;
-
         ChassisRotation = MathUtils.RoughStep(ChassisRotation, DesiredChassisRotation, Properties.TurningSpeed * RuntimeData.DeltaTime);
-
         Velocity = Vector2.UnitY.Rotate(ChassisRotation) * Speed;
     }
     public override void Destroy(ITankHurtContext context, bool netSend) {
@@ -415,7 +482,7 @@ public class PlayerTank : Tank {
             }
         }
         else
-            AddLives(-1);
+            LocalCampaignRules.ChangeLife(Lives, LocalGameSession.Current, PlayerId, -1);
 
         Remove(false);
 
@@ -583,7 +650,7 @@ public class PlayerTank : Tank {
             return;
 
         if (!MainMenuUI.IsActive) {
-            if (NetPlay.IsClientMatched(PlayerId)) {
+            if (ControlledHere) {
                 var tex = GameResources.GetGameResource<Texture2D>("Assets/textures/ui/bullet_ui");
                 var scale = 0.5f; // the graphic gets smaller for each availiable shell.
                 for (int i = 0; i < Properties.ShellLimit; i++) {
@@ -631,7 +698,7 @@ public class PlayerTank : Tank {
             DrawUtils.DrawStringWithBorder(TankGame.SpriteRenderer, FontGlobals.RebirthFontLarge, pText, new(pos.X, pos.Y + (flip ? 90 : -110).ToResolutionY()), playerColor, Color.White, new Vector2(scale * 2).ToResolution(), 0f, Anchor.Center, 2f);
         }
 
-        if (DebugManager.DebugLevel == 1 || _drawShotPath)
+        if (DebugManager.DebugLevel == 1 || _drawShotPath || _localShotPathHeld)
             DrawShootPath();
 
         if (Properties.Invisible && CampaignGlobals.InMission)

--- a/GameContent/UI/CampaignCompleteUI.cs
+++ b/GameContent/UI/CampaignCompleteUI.cs
@@ -10,11 +10,13 @@ using System.Threading.Tasks;
 using TanksRebirth.Enums;
 using TanksRebirth.GameContent.Globals;
 using TanksRebirth.GameContent.Systems;
+using TanksRebirth.GameContent.Systems.LocalCoop;
 using TanksRebirth.Internals;
 using TanksRebirth.Internals.Common;
 using TanksRebirth.Internals.Common.Framework.Audio;
 using TanksRebirth.Internals.Common.GameUI;
 using TanksRebirth.Internals.Common.Utilities;
+using TanksRebirth.Net;
 
 using Microsoft.Xna.Framework.Input;
 using TanksRebirth.GameContent.ID;
@@ -270,14 +272,14 @@ public static class CampaignCompleteUI {
         DrawUtils.DrawStringWithShadow(TankGame.SpriteRenderer, FontGlobals.RebirthFont, new Vector2(width.ToResolutionX() / 2, WindowUtils.WindowHeight / 3 + 5.ToResolutionY()), Vector2.One,
             txt, Color.DeepSkyBlue, Vector2.One.ToResolution(), 1f, Anchor.TopCenter, 0.4f);
 
-        string[] funFacts =
-        {
+        var funFacts = new List<string> {
             $"% Shots Hit: {ShotToKillRatio * 100:0}% ({ShellHits}/{ShellsFired})",
             $"% Mine Effect: {MineToKillRatio * 100:0}% ({MineHits}/{MinesLaid})",
-            $"% Lives Earned: {LifeRatio * 100:0}% ({LivesRemaining}/{TotalPossibleLives})",
             $"% Missions Complete: {MissionRatio * 100:0}% ({CampaignGlobals.LoadedCampaign.CurrentMissionId + 1}/{CampaignGlobals.LoadedCampaign.CachedMissions.Length})"
         };
-        for (int i = 0; i < funFacts.Length; i++) {
+        if (Client.IsConnected() || LocalCampaignRules.ShouldUseLives(LocalGameSession.Current))
+            funFacts.Insert(2, $"% Lives Earned: {LifeRatio * 100:0}% ({LivesRemaining}/{TotalPossibleLives})");
+        for (int i = 0; i < funFacts.Count; i++) {
             var ff = funFacts[i];
 
             DrawUtils.DrawStringWithShadow(TankGame.SpriteRenderer, FontGlobals.RebirthFont, new Vector2(8.ToResolutionX(), WindowUtils.WindowHeight / 3 + (75 + (i * 25)).ToResolutionY()), Vector2.One,
@@ -395,7 +397,9 @@ public static class CampaignCompleteUI {
 
         ShotToKillRatio = (float)ShellHits / ShellsFired;
         MineToKillRatio = (float)MineHits / MinesLaid;
-        LifeRatio = (float)LivesRemaining / TotalPossibleLives;
+        LifeRatio = Client.IsConnected() || LocalCampaignRules.ShouldUseLives(LocalGameSession.Current)
+            ? (float)LivesRemaining / TotalPossibleLives
+            : 1f;
         MissionRatio = (float)(CampaignGlobals.LoadedCampaign.CurrentMissionId + 1) / CampaignGlobals.LoadedCampaign.CachedMissions.Length;
 
         if (float.IsNaN(ShotToKillRatio))

--- a/GameContent/UI/GameSceneUI.cs
+++ b/GameContent/UI/GameSceneUI.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Xna.Framework.Graphics;
 using TanksRebirth.GameContent.Globals;
 using TanksRebirth.GameContent.Systems;
@@ -9,6 +10,7 @@ using TanksRebirth.GameContent.ID;
 using TanksRebirth.Net;
 using TanksRebirth.Internals.Common;
 using TanksRebirth.GameContent.Systems.AI;
+using TanksRebirth.GameContent.Systems.LocalCoop;
 
 namespace TanksRebirth.GameContent.UI;
 
@@ -17,7 +19,7 @@ public static class GameSceneUI {
         // put any initialization logic here if needed
     }
     public static void DrawScores() {
-        var drawCount = Client.IsConnected() ? Server.CurrentClientCount : 1;
+        var drawCount = Client.IsConnected() ? Server.CurrentClientCount : LocalGameSession.Current.PlayerCount;
         for (int i = 0; i < drawCount; i++) {
 
             float y = WindowUtils.WindowHeight * 0.9f;
@@ -25,7 +27,25 @@ public static class GameSceneUI {
 
             if (i >= 2) y -= WindowUtils.WindowHeight * 0.1f;
 
-            DrawScore(PlayerID.PlayerTankColors[i], PlayerTank.KillCounts[i], y, flipSide: flip, scale: 2f);
+            if (Client.IsConnected()) {
+                DrawScore(PlayerID.PlayerTankColors[i], PlayerTank.KillCounts[i], y, flipSide: flip, scale: 2f);
+                continue;
+            }
+
+            var statusText = LocalCampaignRules.ShouldUseLives(LocalGameSession.Current)
+                ? $"P{i + 1}  K {PlayerTank.KillCounts[i]}  L {PlayerTank.Lives[i]}"
+                : $"P{i + 1}  K {PlayerTank.KillCounts[i]}";
+            var sideLaneWidth = WindowUtils.WindowWidth * 0.22f;
+            var edgeInset = 20f.ToResolutionX();
+            var baseTextScale = 0.375f * 2f.ToResolutionY();
+            var measuredTextWidth = FontGlobals.RebirthFontLarge.MeasureString(statusText).X * baseTextScale;
+            var maxTextWidth = sideLaneWidth - edgeInset * 2f;
+            var textScaleFactor = Math.Min(1f, maxTextWidth / measuredTextWidth);
+            var textX = flip ? WindowUtils.WindowWidth - edgeInset : edgeInset;
+            var textAnchor = flip ? Anchor.RightCenter : Anchor.LeftCenter;
+
+            DrawScore(PlayerID.PlayerTankColors[i], statusText, y, flipSide: flip, scale: 2f,
+                pertrusion: sideLaneWidth, textX: textX, textAnchor: textAnchor, textScaleFactor: textScaleFactor);
         }
     }
     public static void DrawMissionInfoBar() {
@@ -39,7 +59,7 @@ public static class GameSceneUI {
             LevelEditorUI.cachedMission.Name : $"{CampaignGlobals.LoadedCampaign.CurrentMission.Name ?? $"{TankGame.GameLanguage.Mission}"}";
         var infoMeasure = font.MeasureString(missionInfo) * infoScale;
         var infoScaling = 1f - ((float)missionInfo.Length / LevelEditorUI.MAX_MISSION_CHARS) + 0.4f;
-        var tanksRemaining = $"× {AIManager.CountAll()}";
+        var tanksRemaining = $"Ã— {AIManager.CountAll()}";
 
         DrawUtils.DrawTextureWithShadow(TankGame.SpriteRenderer, bar, barPos,
             Vector2.UnitY, IntermissionSystem.BannerColor, Vector2.One.ToResolution(), alpha, Anchor.Center, shadowDistScale: 0.5f, shadowAlpha: 0.5f);
@@ -58,6 +78,11 @@ public static class GameSceneUI {
 
     // helpers
     private static void DrawScore(Color color, int score, float y, bool flipSide = false, float scale = 1f, float pertrusion = 90) {
+        DrawScore(color, score.ToString(), y, flipSide, scale, pertrusion);
+    }
+
+    private static void DrawScore(Color color, string statusText, float y, bool flipSide = false, float scale = 1f,
+        float pertrusion = 90, float? textX = null, Anchor textAnchor = Anchor.Center, float textScaleFactor = 1f) {
         color = ColorUtils.ChangeColorBrightness(color, 0.25f);
         var brighterColor = ColorUtils.ChangeColorBrightness(color, 0.5f);
 
@@ -123,9 +148,10 @@ public static class GameSceneUI {
 
         DrawUtils.DrawStringWithBorderAndShadow(TankGame.SpriteRenderer, FontGlobals.RebirthFontLarge, 
             // draws the text on the right side of the screen
-            new Vector2(flipSide ? pertrusionReal + 10 : pertrusionReal - 10,
+            new Vector2(textX ?? (flipSide ? pertrusionReal + 10 : pertrusionReal - 10),
             y - 7f * scale),
-            Vector2.One, score.ToString(), brighterColor, color, new Vector2(0.375f * scale), 1f, shadowAlpha: 0.5f);
+            Vector2.One, statusText, brighterColor, color, new Vector2(0.375f * scale * textScaleFactor), 1f,
+            textAnchor, shadowAlpha: 0.5f);
     }
 
     // pretty sure this doesn't work.

--- a/GameContent/UI/GameSceneUI.cs
+++ b/GameContent/UI/GameSceneUI.cs
@@ -1,4 +1,5 @@
 using System;
+using FontStashSharp;
 using Microsoft.Xna.Framework.Graphics;
 using TanksRebirth.GameContent.Globals;
 using TanksRebirth.GameContent.Systems;
@@ -11,6 +12,7 @@ using TanksRebirth.Net;
 using TanksRebirth.Internals.Common;
 using TanksRebirth.GameContent.Systems.AI;
 using TanksRebirth.GameContent.Systems.LocalCoop;
+using TanksRebirth.GameContent.Globals.Assets;
 
 namespace TanksRebirth.GameContent.UI;
 
@@ -74,6 +76,49 @@ public static class GameSceneUI {
         DrawUtils.DrawStringWithBorderAndShadow(TankGame.SpriteRenderer, font, barPos + new Vector2(bar.Size().X * 0.375f, -7.5f).ToResolution(),
             Vector2.One, tanksRemaining, IntermissionSystem.BackgroundColor, IntermissionSystem.ColorForBorders, new Vector2(infoScale).ToResolution(),
             alpha, Anchor.BottomRight, shadowDistScale: 1.5f, origMeasureScale: infoScale, shadowAlpha: 0.5f, charSpacing: 5);
+    }
+
+    public static void DrawLocalCoopPovOverlay(LocalCoopPovLayout layout) {
+        var dividerThickness = Math.Max(2, (int)3f.ToResolutionY());
+        var dividerY = layout.PlayerTwo.Y - dividerThickness / 2;
+        TankGame.SpriteRenderer.Draw(
+            TextureGlobals.Pixels[Color.White],
+            new Rectangle(0, dividerY, WindowUtils.WindowWidth, dividerThickness),
+            Color.Black);
+
+        DrawLocalCoopPovPlayerLabel(0, layout.PlayerOne);
+        DrawLocalCoopPovPlayerLabel(1, layout.PlayerTwo);
+    }
+
+    private static void DrawLocalCoopPovPlayerLabel(int playerId, Rectangle viewport) {
+        var resolvedTank = LocalCoopPovRuntime.ResolveCameraTank(playerId);
+        var spectatingPlayerId = resolvedTank?.PlayerId ?? playerId;
+        var text = LocalCoopPovPolicy.BuildHudText(
+            playerId,
+            PlayerTank.KillCounts[playerId],
+            AIManager.CountAll(),
+            LocalCoopPovRuntime.IsPlayerDown(playerId),
+            spectatingPlayerId);
+        var color = PlayerID.PlayerTankColors[playerId];
+        var scale = new Vector2(0.32f).ToResolution();
+        var inset = new Vector2(16f.ToResolutionX(), 12f.ToResolutionY());
+        var position = new Vector2(viewport.X, viewport.Y) + inset;
+        var measured = FontGlobals.RebirthFontLarge.MeasureString(text) * scale;
+        var padding = new Vector2(10f.ToResolutionX(), 6f.ToResolutionY());
+        var background = new Rectangle(
+            (int)(position.X - padding.X),
+            (int)(position.Y - padding.Y),
+            (int)(measured.X + padding.X * 2),
+            (int)(measured.Y + padding.Y * 2));
+
+        TankGame.SpriteRenderer.Draw(TextureGlobals.Pixels[Color.White], background, Color.Black * 0.62f);
+        TankGame.SpriteRenderer.DrawString(
+            FontGlobals.RebirthFontLarge,
+            text,
+            position + new Vector2(2f).ToResolution(),
+            Color.Black,
+            scale);
+        TankGame.SpriteRenderer.DrawString(FontGlobals.RebirthFontLarge, text, position, color, scale);
     }
 
     // helpers

--- a/GameContent/UI/MainMenu/MainMenuUI.Campaigns.cs
+++ b/GameContent/UI/MainMenu/MainMenuUI.Campaigns.cs
@@ -14,6 +14,7 @@ using TanksRebirth.GameContent.Speedrunning;
 using TanksRebirth.Internals;
 using TanksRebirth.GameContent.Globals;
 using TanksRebirth.GameContent.Systems;
+using TanksRebirth.GameContent.Systems.LocalCoop;
 using TanksRebirth.Internals.Common.Framework.Audio;
 using TanksRebirth.Internals.UI;
 
@@ -81,6 +82,10 @@ public static partial class MainMenuUI {
             var missions = campaign.CachedMissions;
             foreach (var mission in missions)
                 numTanks += mission.Tanks.Count(x => !x.IsPlayer);
+            var lifeMetadata = LocalGameSession.Current.IsLocalCoop
+                ? string.Empty
+                : $"\nStarting Lives: {campaign.MetaData.StartingLives}" +
+                  $"\nBonus Life Count: {campaign.CachedMissions.Count(x => x.GrantsExtraLife)}";
 
             var elem = new UITextButton(Path.GetFileNameWithoutExtension(name), FontGlobals.RebirthFont, Color.White, 0.8f) {
                 IsVisible = true,
@@ -89,8 +94,7 @@ public static partial class MainMenuUI {
                 $"\n\nName: {campaign.MetaData.Name}" +
                 $"\nDescription: {campaign.MetaData.Description}" +
                 $"\nVersion: {campaign.MetaData.Version}" +
-                $"\nStarting Lives: {campaign.MetaData.StartingLives}" +
-                $"\nBonus Life Count: {campaign.CachedMissions.Count(x => x.GrantsExtraLife)}" +
+                lifeMetadata +
                 $"\nTags: {string.Join(", ", campaign.MetaData.Tags)}" +
                 $"\n\nMiddle click to DELETE ME."
             };
@@ -110,6 +114,9 @@ public static partial class MainMenuUI {
                     SoundPlayer.SoundError();
                     return;
                 }
+
+                if (Client.IsConnected())
+                    LocalGameSession.Current.StartSinglePlayer();
 
                 var noExt = Path.GetFileNameWithoutExtension(name);
                 PrepareGameplay(noExt, !Client.IsConnected() || Server.CurrentClientCount == 1, false);

--- a/GameContent/UI/MainMenu/MainMenuUI.DifficultiesManager.cs
+++ b/GameContent/UI/MainMenu/MainMenuUI.DifficultiesManager.cs
@@ -258,7 +258,8 @@ public static partial class MainMenuUI {
         POVMode = new("POV Mode", font, Color.White) {
             IsVisible = false,
             Tooltip = "Play the game in the POV of your tank!" +
-            "\nYou can move around inter-directionally with WASD, and aim by dragging the mouse.",
+            "\nIn Local Co-op, P1 plays on top and P2 below in horizontal split-screen." +
+            "\nP1 aims with the mouse; P2 turns with Left/Right arrows.",
             OnLeftClick = (elem) => Difficulties.Types["POV"] = !Difficulties.Types["POV"]
         };
         AiCompanion = new("AI Companion", font, Color.White) {

--- a/GameContent/UI/MainMenu/MainMenuUI.UIManager.cs
+++ b/GameContent/UI/MainMenu/MainMenuUI.UIManager.cs
@@ -146,8 +146,6 @@ public static partial class MainMenuUI
         PlayButton_LocalCoop.SetDimensions(() => new Vector2(700, 450).ToResolution(), () => new Vector2(500, 50).ToResolution());
         PlayButton_LocalCoop.OnLeftClick = (uiElement) => {
             LocalGameSession.Current.StartLocalCoop();
-            if (Difficulties.Types["POV"])
-                Difficulties.Types["POV"] = false;
             SetCampaignDisplay();
             MenuState = UIState.Campaigns;
         };

--- a/GameContent/UI/MainMenu/MainMenuUI.UIManager.cs
+++ b/GameContent/UI/MainMenu/MainMenuUI.UIManager.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using System.Linq;
 using TanksRebirth.GameContent.Globals;
 using TanksRebirth.GameContent.Speedrunning;
+using TanksRebirth.GameContent.Systems;
+using TanksRebirth.GameContent.Systems.LocalCoop;
 using TanksRebirth.GameContent.UI.LevelEditor;
 using TanksRebirth.Internals.Common;
 using TanksRebirth.Internals.Common.Framework.Animation;
@@ -49,6 +51,9 @@ public static partial class MainMenuUI
     public static UIState MenuState {
         get => _menuState;
         set {
+            if (_menuState == UIState.Campaigns && value == UIState.PlayList)
+                LocalGameSession.Current.StartSinglePlayer();
+
             _menuState = value;
 
             if (MenuCameraManipulations.ContainsKey(value)) {
@@ -76,6 +81,7 @@ public static partial class MainMenuUI
     }
     public static UITextButton PlayButton;
     public static UITextButton PlayButton_SinglePlayer;
+    public static UITextButton PlayButton_LocalCoop;
     public static UITextButton PlayButton_LevelEditor;
     public static UITextButton PlayButton_Multiplayer;
     public static UITextButton StartMPGameButton;
@@ -105,6 +111,7 @@ public static partial class MainMenuUI
         PlayButton_Multiplayer.SetDimensions(() => new Vector2(700, 750).ToResolution(), () => new Vector2(500, 50).ToResolution());
 
         PlayButton_Multiplayer.OnLeftClick = (uiElement) => {
+            LocalGameSession.Current.StartSinglePlayer();
             SetPlayButtonsVisibility(false);
             SetMPButtonsVisibility(true);
             MenuState = UIState.Mulitplayer;
@@ -124,12 +131,27 @@ public static partial class MainMenuUI
             IsVisible = false,
             Tooltip = TankGame.GameLanguage.SinglePlayerFlavor
         };
-        PlayButton_SinglePlayer.SetDimensions(() => new Vector2(700, 450).ToResolution(), () => new Vector2(500, 50).ToResolution());
+        PlayButton_SinglePlayer.SetDimensions(() => new Vector2(700, 350).ToResolution(), () => new Vector2(500, 50).ToResolution());
 
         PlayButton_SinglePlayer.OnLeftClick = (uiElement) => {
+            LocalGameSession.Current.StartSinglePlayer();
             SetCampaignDisplay();
             MenuState = UIState.Campaigns;
         };
+
+        PlayButton_LocalCoop = new("Local Co-op", font, Color.WhiteSmoke) {
+            IsVisible = false,
+            Tooltip = "Two players on this Mac: P1 uses keyboard and mouse; P2 uses I/J/K/L plus arrow keys."
+        };
+        PlayButton_LocalCoop.SetDimensions(() => new Vector2(700, 450).ToResolution(), () => new Vector2(500, 50).ToResolution());
+        PlayButton_LocalCoop.OnLeftClick = (uiElement) => {
+            LocalGameSession.Current.StartLocalCoop();
+            if (Difficulties.Types["POV"])
+                Difficulties.Types["POV"] = false;
+            SetCampaignDisplay();
+            MenuState = UIState.Campaigns;
+        };
+
         InitializeDifficultyButtons();
 
         PlayButton_LevelEditor = new(TankGame.GameLanguage.LevelEditor, font, Color.WhiteSmoke) {
@@ -138,6 +160,7 @@ public static partial class MainMenuUI
         };
         PlayButton_LevelEditor.SetDimensions(() => new Vector2(700, 650).ToResolution(), () => new Vector2(500, 50).ToResolution());
         PlayButton_LevelEditor.OnLeftClick = (b) => {
+            LocalGameSession.Current.StartSinglePlayer();
             LevelEditorUI.Initialize();
             LevelEditorUI.TryOpen();
         };
@@ -168,6 +191,7 @@ public static partial class MainMenuUI
     private static void HideAll() {
         PlayButton.IsVisible = false;
         PlayButton_SinglePlayer.IsVisible = false;
+        PlayButton_LocalCoop.IsVisible = false;
         PlayButton_Multiplayer.IsVisible = false;
         PlayButton_LevelEditor.IsVisible = false;
 
@@ -175,6 +199,7 @@ public static partial class MainMenuUI
     }
     internal static void SetPlayButtonsVisibility(bool visible) {
         PlayButton_SinglePlayer.IsVisible = visible;
+        PlayButton_LocalCoop.IsVisible = visible;
         PlayButton_LevelEditor.IsVisible = visible;
         PlayButton_Multiplayer.IsVisible = visible;
         DifficultiesButton.IsVisible = visible;
@@ -250,6 +275,8 @@ public static partial class MainMenuUI
 
     }
     public static void OpenUI() {
+        LocalGameSession.Current.StartSinglePlayer();
+
         if (!Speedrun.AreSpeedrunsFetched) {
             Speedrun.AreSpeedrunsFetched = true;
             Speedrun.GetSpeedruns();

--- a/GameContent/UI/MainMenu/MainMenuUI.cs
+++ b/GameContent/UI/MainMenu/MainMenuUI.cs
@@ -98,7 +98,7 @@ public static partial class MainMenuUI
         InitializeMain(font);
         InitializeMP(font);
 
-        _menuElements = [PlayButton, PlayButton_SinglePlayer, PlayButton_LevelEditor, PlayButton_Multiplayer, ConnectToServerButton,
+        _menuElements = [PlayButton, PlayButton_SinglePlayer, PlayButton_LocalCoop, PlayButton_LevelEditor, PlayButton_Multiplayer, ConnectToServerButton,
             CreateServerButton, UsernameInput, IPInput, PortInput, PasswordInput, ServerNameInput,
             DifficultiesButton ];
 

--- a/Graphics/LocalCoopPovRenderer.cs
+++ b/Graphics/LocalCoopPovRenderer.cs
@@ -1,0 +1,43 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using TanksRebirth.GameContent.Systems.LocalCoop;
+
+namespace TanksRebirth.Graphics;
+
+public static class LocalCoopPovRenderer {
+    private static RenderTarget2D? _playerOneTarget;
+    private static RenderTarget2D? _playerTwoTarget;
+
+    public static RenderTarget2D? PlayerOneTarget => _playerOneTarget;
+    public static RenderTarget2D? PlayerTwoTarget => _playerTwoTarget;
+
+    public static void EnsureTargets(GraphicsDevice device, LocalCoopPovLayout layout) {
+        EnsureTarget(device, ref _playerOneTarget, LocalCoopPovPolicy.TargetSize(layout.PlayerOne));
+        EnsureTarget(device, ref _playerTwoTarget, LocalCoopPovPolicy.TargetSize(layout.PlayerTwo));
+    }
+
+    public static void DisposeTargets() {
+        _playerOneTarget?.Dispose();
+        _playerTwoTarget?.Dispose();
+        _playerOneTarget = null;
+        _playerTwoTarget = null;
+    }
+
+    private static void EnsureTarget(GraphicsDevice device, ref RenderTarget2D? target, Point desiredSize) {
+        var currentSize = target is null ? Point.Zero : new Point(target.Width, target.Height);
+        if (target is not null && !LocalCoopPovPolicy.ShouldRecreateTarget(currentSize, target.IsDisposed, desiredSize))
+            return;
+
+        target?.Dispose();
+        var presentation = device.PresentationParameters;
+        target = new RenderTarget2D(
+            device,
+            desiredSize.X,
+            desiredSize.Y,
+            false,
+            presentation.BackBufferFormat,
+            presentation.DepthStencilFormat,
+            0,
+            RenderTargetUsage.DiscardContents);
+    }
+}

--- a/Graphics/RoomScene.cs
+++ b/Graphics/RoomScene.cs
@@ -298,6 +298,8 @@ public static class RoomScene {
     // render
 
     public static void Render() {
+        View = CameraGlobals.GameView;
+        Projection = CameraGlobals.GameProjection;
         _transparentFaces.Clear();
         World = Matrix.CreateScale(Scale)
             * Matrix.CreateFromYawPitchRoll(Rotation.Z, Rotation.Y, Rotation.X)

--- a/Internals/Common/Framework/Input/LocalPlayerInputFrame.cs
+++ b/Internals/Common/Framework/Input/LocalPlayerInputFrame.cs
@@ -7,6 +7,7 @@ public enum LocalAimSource { Mouse, Direction }
 public readonly record struct LocalPlayerInputFrame(
     Vector2 Movement,
     Vector2 Aim,
+    Vector2 AimInput,
     LocalAimSource AimSource,
     bool FireJustPressed,
     bool MineJustPressed,

--- a/Internals/Common/Framework/Input/LocalPlayerInputFrame.cs
+++ b/Internals/Common/Framework/Input/LocalPlayerInputFrame.cs
@@ -1,0 +1,13 @@
+using Microsoft.Xna.Framework;
+
+namespace TanksRebirth.Internals.Common.Framework.Input;
+
+public enum LocalAimSource { Mouse, Direction }
+
+public readonly record struct LocalPlayerInputFrame(
+    Vector2 Movement,
+    Vector2 Aim,
+    LocalAimSource AimSource,
+    bool FireJustPressed,
+    bool MineJustPressed,
+    bool ShotPathHeld);

--- a/Internals/Common/Framework/Input/LocalPlayerInputRouter.cs
+++ b/Internals/Common/Framework/Input/LocalPlayerInputRouter.cs
@@ -1,0 +1,61 @@
+using System;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
+
+namespace TanksRebirth.Internals.Common.Framework.Input;
+
+public sealed class LocalPlayerInputRouter {
+    private readonly LocalPlayerInputFrame[] _frames = [
+        new(Vector2.Zero, Vector2.Zero, LocalAimSource.Mouse, false, false, false),
+        new(Vector2.Zero, -Vector2.UnitY, LocalAimSource.Direction, false, false, false),
+    ];
+
+    private Vector2 _playerTwoAim = -Vector2.UnitY;
+
+    public static LocalPlayerInputRouter Runtime { get; } = new();
+
+    public void Update(
+        KeyboardState currentKeyboard,
+        KeyboardState previousKeyboard,
+        MouseState currentMouse,
+        MouseState previousMouse) {
+        _frames[0] = new LocalPlayerInputFrame(
+            ReadDirection(currentKeyboard, Keys.W, Keys.S, Keys.A, Keys.D),
+            new Vector2(currentMouse.X, currentMouse.Y),
+            LocalAimSource.Mouse,
+            currentMouse.LeftButton == ButtonState.Pressed && previousMouse.LeftButton == ButtonState.Released,
+            JustPressed(currentKeyboard, previousKeyboard, Keys.Space),
+            currentKeyboard.IsKeyDown(Keys.Q));
+
+        var playerTwoAim = ReadDirection(currentKeyboard, Keys.Up, Keys.Down, Keys.Left, Keys.Right);
+        if (playerTwoAim != Vector2.Zero)
+            _playerTwoAim = playerTwoAim;
+
+        _frames[1] = new LocalPlayerInputFrame(
+            ReadDirection(currentKeyboard, Keys.I, Keys.K, Keys.J, Keys.L),
+            _playerTwoAim,
+            LocalAimSource.Direction,
+            JustPressed(currentKeyboard, previousKeyboard, Keys.Enter),
+            JustPressed(currentKeyboard, previousKeyboard, Keys.RightShift),
+            currentKeyboard.IsKeyDown(Keys.P));
+    }
+
+    public LocalPlayerInputFrame GetFrame(int playerId) {
+        if ((uint)playerId >= _frames.Length)
+            throw new ArgumentOutOfRangeException(nameof(playerId), playerId, "Only local players 0 and 1 are supported.");
+
+        return _frames[playerId];
+    }
+
+    private static Vector2 ReadDirection(KeyboardState state, Keys up, Keys down, Keys left, Keys right) {
+        var direction = Vector2.Zero;
+        if (state.IsKeyDown(up)) direction.Y -= 1;
+        if (state.IsKeyDown(down)) direction.Y += 1;
+        if (state.IsKeyDown(left)) direction.X -= 1;
+        if (state.IsKeyDown(right)) direction.X += 1;
+        return direction == Vector2.Zero ? direction : Vector2.Normalize(direction);
+    }
+
+    private static bool JustPressed(KeyboardState current, KeyboardState previous, Keys key) =>
+        current.IsKeyDown(key) && previous.IsKeyUp(key);
+}

--- a/Internals/Common/Framework/Input/LocalPlayerInputRouter.cs
+++ b/Internals/Common/Framework/Input/LocalPlayerInputRouter.cs
@@ -6,8 +6,8 @@ namespace TanksRebirth.Internals.Common.Framework.Input;
 
 public sealed class LocalPlayerInputRouter {
     private readonly LocalPlayerInputFrame[] _frames = [
-        new(Vector2.Zero, Vector2.Zero, LocalAimSource.Mouse, false, false, false),
-        new(Vector2.Zero, -Vector2.UnitY, LocalAimSource.Direction, false, false, false),
+        new(Vector2.Zero, Vector2.Zero, Vector2.Zero, LocalAimSource.Mouse, false, false, false),
+        new(Vector2.Zero, -Vector2.UnitY, Vector2.Zero, LocalAimSource.Direction, false, false, false),
     ];
 
     private Vector2 _playerTwoAim = -Vector2.UnitY;
@@ -22,6 +22,7 @@ public sealed class LocalPlayerInputRouter {
         _frames[0] = new LocalPlayerInputFrame(
             ReadDirection(currentKeyboard, Keys.W, Keys.S, Keys.A, Keys.D),
             new Vector2(currentMouse.X, currentMouse.Y),
+            new Vector2(currentMouse.X, currentMouse.Y),
             LocalAimSource.Mouse,
             currentMouse.LeftButton == ButtonState.Pressed && previousMouse.LeftButton == ButtonState.Released,
             JustPressed(currentKeyboard, previousKeyboard, Keys.Space),
@@ -34,6 +35,7 @@ public sealed class LocalPlayerInputRouter {
         _frames[1] = new LocalPlayerInputFrame(
             ReadDirection(currentKeyboard, Keys.I, Keys.K, Keys.J, Keys.L),
             _playerTwoAim,
+            playerTwoAim,
             LocalAimSource.Direction,
             JustPressed(currentKeyboard, previousKeyboard, Keys.Enter),
             JustPressed(currentKeyboard, previousKeyboard, Keys.RightShift),

--- a/TankGame.cs
+++ b/TankGame.cs
@@ -41,6 +41,7 @@ using TanksRebirth.GameContent.UI.MainMenu;
 using TanksRebirth.GameContent.UI.LevelEditor;
 using TanksRebirth.GameContent.Systems.ParticleSystem;
 using TanksRebirth.GameContent.Systems.TankSystem;
+using TanksRebirth.GameContent.Systems.LocalCoop;
 using System.Collections.Concurrent;
 
 namespace TanksRebirth;
@@ -91,6 +92,7 @@ public class TankGame : Game {
     public static AchievementPopupHandler VanillaAchievementPopupHandler;
 
     public static RenderTarget2D GameFrameBuffer;
+    public static bool LocalCoopPovRenderedThisFrame { get; private set; }
 
     public static RasterizerState _cachedState;
 
@@ -237,6 +239,7 @@ public class TankGame : Game {
         DiscordRichPresence.Terminate();
 
         CurrentSessionTimer.Stop();
+        LocalCoopPovRenderer.DisposeTargets();
 
         // write end-life metrics
 
@@ -724,6 +727,12 @@ public class TankGame : Game {
             OnResolutionChanged?.Invoke(WindowUtils.WindowWidth, WindowUtils.WindowHeight);
         }
 
+        LocalCoopPovRenderedThisFrame = false;
+        if (LocalCoopPovRuntime.IsActive && PrepareLocalCoopPovBuffers(spriteBatch)) {
+            LocalCoopPovRenderedThisFrame = true;
+            return;
+        }
+
         // TankFootprint.DecalHandler.UpdateRenderTarget();
         GraphicsDevice.SetRenderTarget(GameFrameBuffer);
         GraphicsDevice.Clear(RenderGlobals.BackBufferColor);
@@ -744,6 +753,69 @@ public class TankGame : Game {
         spriteBatch.End();
         // stop drawing the regular game scene
         GraphicsDevice.SetRenderTarget(null);
+    }
+
+    private bool PrepareLocalCoopPovBuffers(SpriteBatch spriteBatch) {
+        var playerOneTank = LocalCoopPovRuntime.ResolveCameraTank(0);
+        var playerTwoTank = LocalCoopPovRuntime.ResolveCameraTank(1);
+        if (playerOneTank is null || playerTwoTank is null)
+            return false;
+
+        var layout = LocalCoopPovPolicy.CreateHorizontalLayout(WindowUtils.WindowWidth, WindowUtils.WindowHeight);
+        LocalCoopPovRenderer.EnsureTargets(GraphicsDevice, layout);
+        var playerOneTarget = LocalCoopPovRenderer.PlayerOneTarget;
+        var playerTwoTarget = LocalCoopPovRenderer.PlayerTwoTarget;
+        if (playerOneTarget is null || playerTwoTarget is null)
+            return false;
+
+        var playerOneCamera = CameraGlobals.CreatePovCamera(
+            playerOneTank.Position,
+            playerOneTank.TurretRotation,
+            (float)playerOneTarget.Width / playerOneTarget.Height);
+        var playerTwoCamera = CameraGlobals.CreatePovCamera(
+            playerTwoTank.Position,
+            playerTwoTank.TurretRotation,
+            (float)playerTwoTarget.Width / playerTwoTarget.Height);
+
+        RenderLocalCoopPovPass(spriteBatch, playerOneTarget, playerOneCamera);
+        RenderLocalCoopPovPass(spriteBatch, playerTwoTarget, playerTwoCamera);
+
+        GraphicsDevice.SetRenderTarget(GameFrameBuffer);
+        GraphicsDevice.Clear(RenderGlobals.BackBufferColor);
+        spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.NonPremultiplied,
+            rasterizerState: RenderGlobals.DefaultRasterizer);
+        spriteBatch.Draw(playerOneTarget, layout.PlayerOne, Color.White);
+        spriteBatch.Draw(playerTwoTarget, layout.PlayerTwo, Color.White);
+        spriteBatch.End();
+        GraphicsDevice.SetRenderTarget(null);
+
+        ApplyPovCamera(playerOneCamera);
+        return true;
+    }
+
+    private void RenderLocalCoopPovPass(SpriteBatch spriteBatch, RenderTarget2D target, PovCameraState camera) {
+        ApplyPovCamera(camera);
+        GraphicsDevice.SetRenderTarget(target);
+        GraphicsDevice.Clear(RenderGlobals.BackBufferColor);
+        GraphicsDevice.DepthStencilState = RenderGlobals.DefaultStencilState;
+        GraphicsDevice.SamplerStates[0] = RenderGlobals.WrappingSampler;
+
+        spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.NonPremultiplied,
+            rasterizerState: RenderGlobals.DefaultRasterizer);
+        RoomScene.Render();
+        CosmeticsUI.RenderCrates();
+        GraphicsDevice.SamplerStates[0] = RenderGlobals.ClampingSampler;
+        GameHandler.RenderAll(includeSharedHud: false);
+        spriteBatch.End();
+    }
+
+    private static void ApplyPovCamera(PovCameraState camera) {
+        CameraGlobals.GameView = camera.View;
+        CameraGlobals.GameProjection = camera.Projection;
+        CameraGlobals.POVCameraPosition = camera.Position;
+        CameraGlobals.RebirthFreecam.Position = camera.Position;
+        RoomScene.View = camera.View;
+        RoomScene.Projection = camera.Projection;
     }
     protected override void Draw(GameTime gameTime) {
         PrepareAllRTs();

--- a/TankGame.cs
+++ b/TankGame.cs
@@ -905,8 +905,14 @@ public class TankGame : Game {
 
         var shouldSeeInfo = !MainMenuUI.IsActive && !LevelEditorUI.IsActive && !CampaignCompleteUI.IsViewingResults;
         if (shouldSeeInfo) {
-            GameSceneUI.DrawScores();
-            GameSceneUI.DrawMissionInfoBar();
+            if (LocalCoopPovRenderedThisFrame) {
+                var layout = LocalCoopPovPolicy.CreateHorizontalLayout(WindowUtils.WindowWidth, WindowUtils.WindowHeight);
+                GameSceneUI.DrawLocalCoopPovOverlay(layout);
+            }
+            else {
+                GameSceneUI.DrawScores();
+                GameSceneUI.DrawMissionInfoBar();
+            }
         }
 
         SpriteRenderer.End();

--- a/TankGame.cs
+++ b/TankGame.cs
@@ -673,6 +673,11 @@ public class TankGame : Game {
         GameShaders.UpdateShaders();
 
         InputUtils.PollEvents();
+        LocalPlayerInputRouter.Runtime.Update(
+            InputUtils.CurrentKeySnapshot,
+            InputUtils.OldKeySnapshot,
+            InputUtils.CurrentMouseSnapshot,
+            InputUtils.OldMouseSnapshot);
 
         bool shouldUpdate = Client.IsConnected() || (IsActive && !GameUI.Paused && !CampaignCompleteUI.IsViewingResults);
         if (!IsCrashInfoVisible) {

--- a/TanksRebirth.csproj
+++ b/TanksRebirth.csproj
@@ -18,6 +18,9 @@
     <None Remove="Icon.bmp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Remove="Tests/**/*.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="Icon.ico" />
     <EmbeddedResource Include="Icon.bmp" />
   </ItemGroup>

--- a/TanksRebirth.sln
+++ b/TanksRebirth.sln
@@ -10,6 +10,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{F82F573E-8D5A-4461-80A3-56AA834B0B29}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TanksRebirth.Tests", "Tests\TanksRebirth.Tests\TanksRebirth.Tests.csproj", "{44ED7B77-1C84-4EE8-AEE5-F0FD47778EDF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -20,11 +24,18 @@ Global
 		{FABEBD2F-4DF3-41F7-804C-00CD771E35E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FABEBD2F-4DF3-41F7-804C-00CD771E35E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FABEBD2F-4DF3-41F7-804C-00CD771E35E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{44ED7B77-1C84-4EE8-AEE5-F0FD47778EDF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{44ED7B77-1C84-4EE8-AEE5-F0FD47778EDF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{44ED7B77-1C84-4EE8-AEE5-F0FD47778EDF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{44ED7B77-1C84-4EE8-AEE5-F0FD47778EDF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A5B64E3A-2E8A-4AC3-BA73-322C4F4FF9B6}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{44ED7B77-1C84-4EE8-AEE5-F0FD47778EDF} = {F82F573E-8D5A-4461-80A3-56AA834B0B29}
 	EndGlobalSection
 EndGlobal

--- a/Tests/TanksRebirth.Tests/CampaignPathTests.cs
+++ b/Tests/TanksRebirth.Tests/CampaignPathTests.cs
@@ -1,0 +1,59 @@
+using TanksRebirth.GameContent.Systems;
+using Xunit;
+
+namespace TanksRebirth.Tests;
+
+public sealed class CampaignPathTests
+{
+    [Fact]
+    public void PreservesRootedPaths()
+    {
+        var saveDirectory = Path.GetFullPath(Path.Combine("My Games", "Tanks Rebirth"));
+        var rootedPath = Path.Combine(saveDirectory, "Campaigns", "Vanilla.campaign");
+
+        Assert.Equal(rootedPath, Campaign.ResolveLoadPath(saveDirectory, rootedPath));
+    }
+
+    [Fact]
+    public void DoesNotDuplicateRelativeSaveDirectory()
+    {
+        var relativeSaveDirectory = Path.Combine("My Games", "Tanks Rebirth");
+        var enumeratedPath = Path.Combine(relativeSaveDirectory, "Campaigns", "Vanilla.campaign");
+
+        Assert.Equal(enumeratedPath, Campaign.ResolveLoadPath(relativeSaveDirectory, enumeratedPath));
+    }
+
+    [Fact]
+    public void CombinesOrdinaryRelativePathsOnce()
+    {
+        var relativeSaveDirectory = Path.Combine("My Games", "Tanks Rebirth");
+
+        Assert.Equal(
+            Path.Combine(relativeSaveDirectory, "Campaigns", "Vanilla.campaign"),
+            Campaign.ResolveLoadPath(relativeSaveDirectory, Path.Combine("Campaigns", "Vanilla.campaign")));
+    }
+
+    [Fact]
+    public void DoesNotDuplicateWindowsAlternateSeparators()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        const string relativeSaveDirectory = "My Games\\Tanks Rebirth";
+        const string alternateSeparatorPath = "My Games/Tanks Rebirth/Campaigns/Vanilla.campaign";
+
+        Assert.Equal(alternateSeparatorPath, Campaign.ResolveLoadPath(relativeSaveDirectory, alternateSeparatorPath));
+    }
+
+    [Fact]
+    public void DoesNotDuplicateDifferentlyCasedWindowsSaveDirectory()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        const string relativeSaveDirectory = "My Games\\Tanks Rebirth";
+        const string differentlyCasedPath = "my games\\tanks rebirth\\Campaigns\\Vanilla.campaign";
+
+        Assert.Equal(differentlyCasedPath, Campaign.ResolveLoadPath(relativeSaveDirectory, differentlyCasedPath));
+    }
+}

--- a/Tests/TanksRebirth.Tests/LocalCampaignRulesTests.cs
+++ b/Tests/TanksRebirth.Tests/LocalCampaignRulesTests.cs
@@ -1,0 +1,386 @@
+using TanksRebirth.GameContent.Systems.LocalCoop;
+using Xunit;
+
+namespace TanksRebirth.Tests;
+
+public sealed class LocalCampaignRulesTests {
+    [Fact]
+    public void ActivePlayerIdsReturnsOnlyBlueForSinglePlayer() {
+        var session = new LocalSession();
+        session.StartSinglePlayer();
+
+        Assert.Equal([0], LocalCampaignRules.ActivePlayerIds(session));
+    }
+
+    [Fact]
+    public void ActivePlayerIdsReturnsBlueAndRedForLocalCoop() {
+        var session = new LocalSession();
+        session.StartLocalCoop();
+
+        Assert.Equal([0, 1], LocalCampaignRules.ActivePlayerIds(session));
+    }
+
+    [Fact]
+    public void ShouldSpawnPlayerExcludesInactivePlayerIds() {
+        var session = new LocalSession();
+        session.StartLocalCoop();
+
+        Assert.True(LocalCampaignRules.ShouldSpawnPlayer(session, 0, livesRemaining: 0));
+        Assert.True(LocalCampaignRules.ShouldSpawnPlayer(session, 1, livesRemaining: 0));
+        Assert.False(LocalCampaignRules.ShouldSpawnPlayer(session, 2, livesRemaining: 3));
+        Assert.False(LocalCampaignRules.ShouldSpawnPlayer(session, 3, livesRemaining: 3));
+    }
+
+    [Fact]
+    public void LocalCoopDoesNotUseLives() {
+        var session = new LocalSession();
+        session.StartLocalCoop();
+
+        Assert.False(LocalCampaignRules.ShouldUseLives(session));
+    }
+
+    [Fact]
+    public void SinglePlayerUsesLives() {
+        var session = new LocalSession();
+        session.StartSinglePlayer();
+
+        Assert.True(LocalCampaignRules.ShouldUseLives(session));
+    }
+
+    [Fact]
+    public void SinglePlayerSpawnRequiresRemainingLife() {
+        var session = new LocalSession();
+        session.StartSinglePlayer();
+
+        Assert.True(LocalCampaignRules.ShouldSpawnPlayer(session, 0, livesRemaining: 1));
+        Assert.False(LocalCampaignRules.ShouldSpawnPlayer(session, 0, livesRemaining: 0));
+    }
+
+    [Fact]
+    public void SinglePlayerUsesEnabledRedTemplateForAiCompanion() {
+        var session = new LocalSession();
+        session.StartSinglePlayer();
+
+        Assert.True(LocalCampaignRules.ShouldUseAiCompanionTemplate(session, aiCompanionEnabled: true, playerId: 1));
+    }
+
+    [Fact]
+    public void LocalCoopNeverUsesActiveRedTemplateForAiCompanion() {
+        var session = new LocalSession();
+        session.StartLocalCoop();
+
+        Assert.False(LocalCampaignRules.ShouldUseAiCompanionTemplate(session, aiCompanionEnabled: true, playerId: 1));
+    }
+
+    [Fact]
+    public void DisabledAiCompanionNeverUsesRedTemplate() {
+        var session = new LocalSession();
+        session.StartSinglePlayer();
+
+        Assert.False(LocalCampaignRules.ShouldUseAiCompanionTemplate(session, aiCompanionEnabled: false, playerId: 1));
+    }
+
+    [Fact]
+    public void AvailableActivePlayerIdsAreDistinctAndKeepTemplateOrder() {
+        var session = new LocalSession();
+        session.StartLocalCoop();
+
+        var available = LocalCampaignRules.AvailableActivePlayerIds(session, [1, 0, 1, 3, 0]);
+
+        Assert.Equal([1, 0], available);
+    }
+
+    [Fact]
+    public void DuplicateBlueTemplateDoesNotSatisfyMissingRedValidation() {
+        var session = new LocalSession();
+        session.StartLocalCoop();
+        var available = LocalCampaignRules.AvailableActivePlayerIds(session, [0, 0]);
+
+        var error = LocalCampaignRules.GetTemplateValidationError(available, session);
+
+        Assert.Equal([0], available);
+        Assert.Equal("The current local session needs 2 active player templates, but this mission provides 1.", error);
+    }
+
+    [Fact]
+    public void BonusLifeDoesNotChangeLocalCoopPlayers() {
+        var session = new LocalSession();
+        session.StartLocalCoop();
+        var lives = new[] { 3, 3, 0, 0 };
+
+        LocalCampaignRules.ChangeLivesForActivePlayers(lives, session, 1);
+
+        Assert.Equal([3, 3, 0, 0], lives);
+    }
+
+    [Fact]
+    public void BonusLifeInSinglePlayerLeavesInactiveSlotsUnchanged() {
+        var session = new LocalSession();
+        session.StartSinglePlayer();
+        var lives = new[] { 3, 7, 8, 9 };
+
+        LocalCampaignRules.ChangeLivesForActivePlayers(lives, session, 1);
+
+        Assert.Equal([4, 7, 8, 9], lives);
+    }
+
+    [Fact]
+    public void ChangeLifeChangesOnlyTheSpecifiedPlayer() {
+        var lives = new[] { 3, 3, 0, 0 };
+        var session = new LocalSession();
+        session.StartSinglePlayer();
+
+        LocalCampaignRules.ChangeLife(lives, session, playerId: 1, delta: -1);
+
+        Assert.Equal([3, 2, 0, 0], lives);
+    }
+
+    [Fact]
+    public void LocalCoopDeathDoesNotChangeLives() {
+        var session = new LocalSession();
+        session.StartLocalCoop();
+        var lives = new[] { 3, 3, 0, 0 };
+
+        LocalCampaignRules.ChangeLife(lives, session, playerId: 1, delta: -1);
+
+        Assert.Equal([3, 3, 0, 0], lives);
+    }
+
+    [Fact]
+    public void LocalCoopBothAvailablePlayersDeadEndsGame() {
+        var session = new LocalSession();
+        session.StartLocalCoop();
+
+        Assert.True(LocalCampaignRules.ShouldEndAsGameOver(
+            session, [0, 1], [false, false, true, true], [3, 3, 0, 0]));
+    }
+
+    [Fact]
+    public void LocalCoopLivingSurvivorContinuesCampaign() {
+        var session = new LocalSession();
+        session.StartLocalCoop();
+
+        Assert.False(LocalCampaignRules.ShouldEndAsGameOver(
+            session, [0, 1], [false, true, false, false], [0, 0, 0, 0]));
+    }
+
+    [Fact]
+    public void MissingActivePlayerTemplateDoesNotBlockGameOver() {
+        var session = new LocalSession();
+        session.StartLocalCoop();
+
+        Assert.True(LocalCampaignRules.ShouldEndAsGameOver(
+            session, [0], [false, true, false, false], [3, 3, 0, 0]));
+    }
+
+    [Fact]
+    public void LocalCoopWithNoAvailablePlayerTemplatesFailsSafeAsGameOver() {
+        var session = new LocalSession();
+        session.StartLocalCoop();
+
+        Assert.True(LocalCampaignRules.ShouldEndAsGameOver(
+            session, [], [false, false, false, false], [3, 3, 0, 0]));
+    }
+
+    [Fact]
+    public void SinglePlayerWithNoAvailablePlayerTemplatesFailsSafeAsGameOver() {
+        var session = new LocalSession();
+        session.StartSinglePlayer();
+
+        Assert.True(LocalCampaignRules.ShouldEndAsGameOver(
+            session, [], [false, false, false, false], [3, 0, 0, 0]));
+    }
+
+    [Fact]
+    public void SinglePlayerWithRemainingLifeDoesNotEndGame() {
+        var session = new LocalSession();
+        session.StartSinglePlayer();
+
+        Assert.False(LocalCampaignRules.ShouldEndAsGameOver(
+            session, [0], [false, false, false, false], [1, 0, 0, 0]));
+    }
+
+    [Fact]
+    public void SinglePlayerWithoutRemainingLifeEndsGame() {
+        var session = new LocalSession();
+        session.StartSinglePlayer();
+
+        Assert.True(LocalCampaignRules.ShouldEndAsGameOver(
+            session, [0], [false, false, false, false], [0, 0, 0, 0]));
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    public void SinglePlayerBonusLifeSequenceMatchesMissionResult(bool victory, bool expected) {
+        var session = new LocalSession();
+        session.StartSinglePlayer();
+
+        Assert.Equal(expected, LocalCampaignRules.ShouldUseBonusLifeSequence(
+            session, missionGrantsBonusLife: true, victory));
+    }
+
+    [Fact]
+    public void LocalCoopNeverUsesBonusLifeSequence() {
+        var session = new LocalSession();
+        session.StartLocalCoop();
+
+        Assert.False(LocalCampaignRules.ShouldUseBonusLifeSequence(
+            session, missionGrantsBonusLife: true, victory: true));
+    }
+
+    [Fact]
+    public void TeamCanContinueWhileAnyActivePlayerHasLives() {
+        Assert.True(LocalCampaignRules.CanTeamContinue([0, 2, 0, 0], [0, 1]));
+    }
+
+    [Fact]
+    public void TeamCannotContinueWhenAllActivePlayersHaveNoLives() {
+        Assert.False(LocalCampaignRules.CanTeamContinue([0, 0, 5, 5], [0, 1]));
+    }
+
+    [Fact]
+    public void TeamContinuationIgnoresRetainedLivesForMissingMissionPlayer() {
+        Assert.False(LocalCampaignRules.CanTeamContinue([0, 3, 0, 0], [0]));
+    }
+
+    [Fact]
+    public void TeamCannotContinueWithNoAvailablePlayerTemplates() {
+        Assert.False(LocalCampaignRules.CanTeamContinue([3, 3, 0, 0], []));
+    }
+
+    [Fact]
+    public void SinglePlayerCanWinWhenDestroyedBlueTeamMatchesFinalTeam() {
+        var session = new LocalSession();
+        session.StartSinglePlayer();
+
+        Assert.True(LocalCampaignRules.IsLocalVictory(session, playerTeams: [2], playerAlive: [false], finalTeam: 2, noTeam: 0));
+    }
+
+    [Theory]
+    [InlineData(3)]
+    [InlineData(0)]
+    public void SinglePlayerCannotWinWhenBlueTeamDoesNotMatchFinalTeam(int blueTeam) {
+        var session = new LocalSession();
+        session.StartSinglePlayer();
+
+        Assert.False(LocalCampaignRules.IsLocalVictory(session, playerTeams: [blueTeam], playerAlive: [false], finalTeam: 2, noTeam: 0));
+    }
+
+    [Fact]
+    public void LocalCoopCanWinWhenLivingP2MatchesAfterP1Destroyed() {
+        var session = new LocalSession();
+        session.StartLocalCoop();
+
+        Assert.True(LocalCampaignRules.IsLocalVictory(session, playerTeams: [2, 2], playerAlive: [false, true], finalTeam: 2, noTeam: 0));
+    }
+
+    [Fact]
+    public void LocalCoopCannotWinWhenBothActivePlayersAreDestroyed() {
+        var session = new LocalSession();
+        session.StartLocalCoop();
+
+        Assert.False(LocalCampaignRules.IsLocalVictory(session, playerTeams: [2, 2], playerAlive: [false, false], finalTeam: 2, noTeam: 0));
+    }
+
+    [Fact]
+    public void LocalCoopVictoryIgnoresLivingMatchingInactiveSlots() {
+        var session = new LocalSession();
+        session.StartLocalCoop();
+
+        Assert.False(LocalCampaignRules.IsLocalVictory(
+            session,
+            playerTeams: [3, 2, 2, 2],
+            playerAlive: [true, false, true, true],
+            finalTeam: 2,
+            noTeam: 0));
+    }
+
+    [Fact]
+    public void LocalVictoryRejectsShortTeamCollection() {
+        var session = new LocalSession();
+        session.StartLocalCoop();
+
+        var error = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            LocalCampaignRules.IsLocalVictory(session, playerTeams: [2], playerAlive: [true, true], finalTeam: 2, noTeam: 0));
+
+        Assert.Equal("playerTeams", error.ParamName);
+    }
+
+    [Fact]
+    public void LocalVictoryRejectsShortAliveCollection() {
+        var session = new LocalSession();
+        session.StartLocalCoop();
+
+        var error = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            LocalCampaignRules.IsLocalVictory(session, playerTeams: [2, 2], playerAlive: [true], finalTeam: 2, noTeam: 0));
+
+        Assert.Equal("playerAlive", error.ParamName);
+    }
+
+    [Fact]
+    public void ZeroActivePlayerTemplatesProducesClearValidationError() {
+        var session = new LocalSession();
+        session.StartLocalCoop();
+
+        var error = LocalCampaignRules.GetTemplateValidationError([], session);
+
+        Assert.Equal("No active player templates are available for the current local session.", error);
+    }
+
+    [Fact]
+    public void EditorMissionDoesNotApplyLocalCampaignFiltering() {
+        Assert.False(LocalCampaignRules.ShouldApplyToMission(clientConnected: false, levelEditorActive: true));
+    }
+
+    [Fact]
+    public void OrdinaryOfflineMissionAppliesLocalCampaignFiltering() {
+        Assert.True(LocalCampaignRules.ShouldApplyToMission(clientConnected: false, levelEditorActive: false));
+    }
+
+    [Fact]
+    public void ConnectedMissionDoesNotApplyLocalCampaignFiltering() {
+        Assert.False(LocalCampaignRules.ShouldApplyToMission(clientConnected: true, levelEditorActive: false));
+    }
+
+    [Fact]
+    public void ChangeLifeRejectsNullLives() {
+        var error = Assert.Throws<ArgumentNullException>(() => LocalCampaignRules.ChangeLife(null!, new LocalSession(), 0, -1));
+
+        Assert.Equal("lives", error.ParamName);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(4)]
+    public void ChangeLifeRejectsInvalidPlayerId(int playerId) {
+        var error = Assert.Throws<ArgumentOutOfRangeException>(() => LocalCampaignRules.ChangeLife([3, 3, 0, 0], new LocalSession(), playerId, -1));
+
+        Assert.Equal("playerId", error.ParamName);
+    }
+
+    [Fact]
+    public void ChangeLivesForActivePlayersRejectsShortLivesArray() {
+        var session = new LocalSession();
+        session.StartLocalCoop();
+
+        var error = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            LocalCampaignRules.ChangeLivesForActivePlayers([3], session, 1));
+
+        Assert.Equal("lives", error.ParamName);
+    }
+
+    [Fact]
+    public void CanTeamContinueRejectsNullLives() {
+        var error = Assert.Throws<ArgumentNullException>(() => LocalCampaignRules.CanTeamContinue(null!, [0]));
+
+        Assert.Equal("lives", error.ParamName);
+    }
+
+    [Fact]
+    public void CanTeamContinueRejectsShortLivesArray() {
+        var error = Assert.Throws<ArgumentOutOfRangeException>(() => LocalCampaignRules.CanTeamContinue([3], [0, 1]));
+
+        Assert.Equal("lives", error.ParamName);
+    }
+}

--- a/Tests/TanksRebirth.Tests/LocalControlPolicyTests.cs
+++ b/Tests/TanksRebirth.Tests/LocalControlPolicyTests.cs
@@ -90,4 +90,22 @@ public sealed class LocalControlPolicyTests {
         Assert.InRange(MathF.Abs(shellDirection.X - aim.X), 0f, 0.0001f);
         Assert.InRange(MathF.Abs(shellDirection.Y - aim.Y), 0f, 0.0001f);
     }
+
+    [Fact]
+    public void PovMovementRotatesForwardInputIntoTurretDirection() {
+        var movement = LocalControlPolicy.ApplyPovMovement(-Vector2.UnitY, turretRotation: 0f);
+
+        Assert.InRange(MathF.Abs(movement.X), 0f, 0.0001f);
+        Assert.InRange(MathF.Abs(movement.Y - 1f), 0f, 0.0001f);
+    }
+
+    [Theory]
+    [InlineData(1f, -0.2f)]
+    [InlineData(-1f, 0.2f)]
+    [InlineData(0f, 0f)]
+    public void PovYawMatchesExistingMouseDirection(float horizontalInput, float expected) {
+        var rotation = LocalControlPolicy.ApplyPovYaw(0f, horizontalInput, 0.2f);
+
+        Assert.Equal(expected, rotation, 4);
+    }
 }

--- a/Tests/TanksRebirth.Tests/LocalControlPolicyTests.cs
+++ b/Tests/TanksRebirth.Tests/LocalControlPolicyTests.cs
@@ -1,0 +1,93 @@
+using Microsoft.Xna.Framework;
+using TanksRebirth.GameContent.Systems.LocalCoop;
+using Xunit;
+
+namespace TanksRebirth.Tests;
+
+public sealed class LocalControlPolicyTests {
+    [Fact]
+    public void LocalCoopMovementKeyCannotRunLegacyDebugShellShortcut() {
+        Assert.False(LocalControlPolicy.ShouldRunLegacyDebugShellShortcut(
+            debuggingEnabled: true, debugLevel: 0, clientConnected: false, localCoop: true, levelEditorActive: false, keyJustPressed: true));
+    }
+
+    [Fact]
+    public void NonDebugPlayCannotRunLegacyDebugShellShortcut() {
+        Assert.False(LocalControlPolicy.ShouldRunLegacyDebugShellShortcut(
+            debuggingEnabled: false, debugLevel: 0, clientConnected: false, localCoop: false, levelEditorActive: false, keyJustPressed: true));
+    }
+
+    [Fact]
+    public void ExplicitSoloGeneralDebugModeCanRunLegacyDebugShellShortcut() {
+        Assert.True(LocalControlPolicy.ShouldRunLegacyDebugShellShortcut(
+            debuggingEnabled: true, debugLevel: 0, clientConnected: false, localCoop: false, levelEditorActive: false, keyJustPressed: true));
+    }
+
+    [Fact]
+    public void ConnectedGeneralDebugModeCannotRunLegacyDebugShellShortcut() {
+        Assert.False(LocalControlPolicy.ShouldRunLegacyDebugShellShortcut(
+            debuggingEnabled: true, debugLevel: 0, clientConnected: true, localCoop: false, levelEditorActive: false, keyJustPressed: true));
+    }
+
+    [Fact]
+    public void LevelEditorGeneralDebugModeCannotRunLegacyDebugShellShortcut() {
+        Assert.False(LocalControlPolicy.ShouldRunLegacyDebugShellShortcut(
+            debuggingEnabled: true, debugLevel: 0, clientConnected: false, localCoop: false, levelEditorActive: true, keyJustPressed: true));
+    }
+
+    [Theory]
+    [InlineData(false, false, 0, true)]
+    [InlineData(false, false, 1, false)]
+    [InlineData(false, true, 0, true)]
+    [InlineData(false, true, 1, true)]
+    [InlineData(false, true, 2, false)]
+    [InlineData(true, true, 1, false)]
+    public void ControlEligibilityIsIsolated(bool networkConnected, bool localCoop, int playerId, bool expected) {
+        var session = new LocalSession();
+        if (localCoop)
+            session.StartLocalCoop();
+
+        Assert.Equal(expected, LocalControlPolicy.CanControlOffline(networkConnected, session, playerId));
+    }
+
+    [Theory]
+    [InlineData(true, false, 0f, 0f, 0f, 0, 1, true)]
+    [InlineData(false, false, 0f, 0f, 0f, 0, 1, false)]
+    [InlineData(true, true, 0f, 0f, 0f, 0, 1, false)]
+    [InlineData(true, false, 1f, 0f, 0f, 0, 1, false)]
+    [InlineData(true, false, 0f, 1f, 0f, 0, 1, false)]
+    [InlineData(true, false, 0f, 0f, 1f, 0, 1, false)]
+    [InlineData(true, false, 0f, 0f, 0f, 1, 1, false)]
+    public void LocalWeaponUseRequiresEveryGuard(
+        bool gameplayInputAllowed,
+        bool stationary,
+        float shootStun,
+        float mineStun,
+        float cooldown,
+        int ownedCount,
+        int capacity,
+        bool expected) {
+        Assert.Equal(expected, LocalControlPolicy.CanUseLocalWeapon(
+            gameplayInputAllowed,
+            stationary,
+            shootStun,
+            mineStun,
+            cooldown,
+            ownedCount,
+            capacity));
+    }
+
+    [Theory]
+    [InlineData(1f, 0f)]
+    [InlineData(-1f, 0f)]
+    [InlineData(0f, 1f)]
+    [InlineData(0f, -1f)]
+    public void DirectionalTurretRotationFiresTowardAim(float aimX, float aimY) {
+        var aim = new Vector2(aimX, aimY);
+        var rotation = LocalControlPolicy.DirectionalTurretRotation(aim);
+        var shellDirection = new Vector2(MathF.Sin(rotation), MathF.Cos(rotation));
+
+        Assert.InRange(MathF.Abs(shellDirection.X - aim.X), 0f, 0.0001f);
+        Assert.InRange(MathF.Abs(shellDirection.Y - aim.Y), 0f, 0.0001f);
+    }
+}

--- a/Tests/TanksRebirth.Tests/LocalCoopPovPolicyTests.cs
+++ b/Tests/TanksRebirth.Tests/LocalCoopPovPolicyTests.cs
@@ -96,6 +96,20 @@ public sealed class LocalCoopPovPolicyTests {
     }
 
     [Fact]
+    public void ActivePlayerHudShowsKillsAndEnemies() {
+        Assert.Equal(
+            "P1   K 3   ENEMIES 7",
+            LocalCoopPovPolicy.BuildHudText(0, kills: 3, enemies: 7, down: false, spectatingPlayerId: 0));
+    }
+
+    [Fact]
+    public void DestroyedPlayerHudShowsSpectatingTarget() {
+        Assert.Equal(
+            "P2   K 1   ENEMIES 4   DOWN - SPECTATING P1",
+            LocalCoopPovPolicy.BuildHudText(1, kills: 1, enemies: 4, down: true, spectatingPlayerId: 0));
+    }
+
+    [Fact]
     public void PovCameraFactoryProducesFiniteMatrices() {
         var camera = CameraGlobals.CreatePovCamera(new Vector2(10, 20), MathHelper.PiOver4, 16f / 5f);
 

--- a/Tests/TanksRebirth.Tests/LocalCoopPovPolicyTests.cs
+++ b/Tests/TanksRebirth.Tests/LocalCoopPovPolicyTests.cs
@@ -47,6 +47,24 @@ public sealed class LocalCoopPovPolicyTests {
         Assert.Equal(new Point(1440, 451), LocalCoopPovPolicy.TargetSize(layout.PlayerTwo));
     }
 
+    [Theory]
+    [InlineData(1440, 450, false, 1440, 450, false)]
+    [InlineData(1440, 450, true, 1440, 450, true)]
+    [InlineData(1440, 450, false, 1440, 451, true)]
+    [InlineData(720, 900, false, 1440, 450, true)]
+    public void TargetRecreationOnlyOccursForDisposalOrSizeChange(
+        int currentWidth,
+        int currentHeight,
+        bool disposed,
+        int desiredWidth,
+        int desiredHeight,
+        bool expected) {
+        Assert.Equal(expected, LocalCoopPovPolicy.ShouldRecreateTarget(
+            new Point(currentWidth, currentHeight),
+            disposed,
+            new Point(desiredWidth, desiredHeight)));
+    }
+
     [Fact]
     public void DestroyedPlayerSpectatesSurvivor() {
         Assert.Equal(1, LocalCoopPovPolicy.ResolveCameraPlayerId(

--- a/Tests/TanksRebirth.Tests/LocalCoopPovPolicyTests.cs
+++ b/Tests/TanksRebirth.Tests/LocalCoopPovPolicyTests.cs
@@ -1,0 +1,94 @@
+using System;
+using Microsoft.Xna.Framework;
+using TanksRebirth.GameContent.Globals;
+using TanksRebirth.GameContent.Systems.LocalCoop;
+using Xunit;
+
+namespace TanksRebirth.Tests;
+
+public sealed class LocalCoopPovPolicyTests {
+    [Fact]
+    public void SplitScreenRequiresOfflineLocalCoopPovGameplay() {
+        Assert.True(LocalCoopPovPolicy.ShouldUseSplitScreen(
+            localCoop: true, pov: true, mainMenu: false, levelEditor: false, connected: false));
+
+        Assert.False(LocalCoopPovPolicy.ShouldUseSplitScreen(
+            localCoop: false, pov: true, mainMenu: false, levelEditor: false, connected: false));
+        Assert.False(LocalCoopPovPolicy.ShouldUseSplitScreen(
+            localCoop: true, pov: false, mainMenu: false, levelEditor: false, connected: false));
+        Assert.False(LocalCoopPovPolicy.ShouldUseSplitScreen(
+            localCoop: true, pov: true, mainMenu: true, levelEditor: false, connected: false));
+        Assert.False(LocalCoopPovPolicy.ShouldUseSplitScreen(
+            localCoop: true, pov: true, mainMenu: false, levelEditor: true, connected: false));
+        Assert.False(LocalCoopPovPolicy.ShouldUseSplitScreen(
+            localCoop: true, pov: true, mainMenu: false, levelEditor: false, connected: true));
+    }
+
+    [Fact]
+    public void HorizontalLayoutCoversOddHeightWithoutOverlap() {
+        var layout = LocalCoopPovPolicy.CreateHorizontalLayout(1440, 901);
+
+        Assert.Equal(new Rectangle(0, 0, 1440, 450), layout.PlayerOne);
+        Assert.Equal(new Rectangle(0, 450, 1440, 451), layout.PlayerTwo);
+        Assert.Equal(901, layout.PlayerOne.Height + layout.PlayerTwo.Height);
+    }
+
+    [Fact]
+    public void InvalidDimensionsAreRejected() {
+        Assert.Throws<ArgumentOutOfRangeException>(() => LocalCoopPovPolicy.CreateHorizontalLayout(0, 900));
+        Assert.Throws<ArgumentOutOfRangeException>(() => LocalCoopPovPolicy.CreateHorizontalLayout(1440, 1));
+    }
+
+    [Fact]
+    public void TargetSizesMatchDestinationRectangles() {
+        var layout = LocalCoopPovPolicy.CreateHorizontalLayout(1440, 901);
+
+        Assert.Equal(new Point(1440, 450), LocalCoopPovPolicy.TargetSize(layout.PlayerOne));
+        Assert.Equal(new Point(1440, 451), LocalCoopPovPolicy.TargetSize(layout.PlayerTwo));
+    }
+
+    [Fact]
+    public void DestroyedPlayerSpectatesSurvivor() {
+        Assert.Equal(1, LocalCoopPovPolicy.ResolveCameraPlayerId(
+            requestedPlayerId: 0,
+            playerOneAvailable: true,
+            playerOneDestroyed: true,
+            playerTwoAvailable: true,
+            playerTwoDestroyed: false));
+    }
+
+    [Fact]
+    public void ActivePlayerKeepsOwnCamera() {
+        Assert.Equal(1, LocalCoopPovPolicy.ResolveCameraPlayerId(
+            requestedPlayerId: 1,
+            playerOneAvailable: true,
+            playerOneDestroyed: false,
+            playerTwoAvailable: true,
+            playerTwoDestroyed: false));
+    }
+
+    [Fact]
+    public void NoAvailablePlayerReturnsNoCamera() {
+        Assert.Equal(-1, LocalCoopPovPolicy.ResolveCameraPlayerId(
+            requestedPlayerId: 0,
+            playerOneAvailable: false,
+            playerOneDestroyed: false,
+            playerTwoAvailable: false,
+            playerTwoDestroyed: false));
+    }
+
+    [Fact]
+    public void PovCameraFactoryProducesFiniteMatrices() {
+        var camera = CameraGlobals.CreatePovCamera(new Vector2(10, 20), MathHelper.PiOver4, 16f / 5f);
+
+        Assert.True(IsFinite(camera.View));
+        Assert.True(IsFinite(camera.Projection));
+        Assert.Equal(new Vector3(10, 0, 20), camera.Position);
+    }
+
+    private static bool IsFinite(Matrix matrix) =>
+        float.IsFinite(matrix.M11) && float.IsFinite(matrix.M12) && float.IsFinite(matrix.M13) && float.IsFinite(matrix.M14)
+        && float.IsFinite(matrix.M21) && float.IsFinite(matrix.M22) && float.IsFinite(matrix.M23) && float.IsFinite(matrix.M24)
+        && float.IsFinite(matrix.M31) && float.IsFinite(matrix.M32) && float.IsFinite(matrix.M33) && float.IsFinite(matrix.M34)
+        && float.IsFinite(matrix.M41) && float.IsFinite(matrix.M42) && float.IsFinite(matrix.M43) && float.IsFinite(matrix.M44);
+}

--- a/Tests/TanksRebirth.Tests/LocalPlayerInputRouterTests.cs
+++ b/Tests/TanksRebirth.Tests/LocalPlayerInputRouterTests.cs
@@ -1,0 +1,140 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
+using TanksRebirth.Internals.Common.Framework.Input;
+using Xunit;
+
+namespace TanksRebirth.Tests;
+
+public sealed class LocalPlayerInputRouterTests {
+    [Fact]
+    public void P1KeysDoNotMoveP2() {
+        var router = new LocalPlayerInputRouter();
+        router.Update(new KeyboardState(Keys.W), new KeyboardState(), default, default);
+
+        Assert.Equal(new Vector2(0, -1), router.GetFrame(0).Movement);
+        Assert.Equal(Vector2.Zero, router.GetFrame(1).Movement);
+    }
+
+    [Fact]
+    public void P2KeysDoNotMoveP1() {
+        var router = new LocalPlayerInputRouter();
+        router.Update(new KeyboardState(Keys.I), new KeyboardState(), default, default);
+
+        Assert.Equal(Vector2.Zero, router.GetFrame(0).Movement);
+        Assert.Equal(new Vector2(0, -1), router.GetFrame(1).Movement);
+    }
+
+    [Fact]
+    public void P2AimRetainsItsLastDirection() {
+        var router = new LocalPlayerInputRouter();
+        router.Update(new KeyboardState(Keys.Right), new KeyboardState(), default, default);
+        var aimed = router.GetFrame(1).Aim;
+
+        router.Update(new KeyboardState(), new KeyboardState(Keys.Right), default, default);
+
+        Assert.Equal(Vector2.UnitX, aimed);
+        Assert.Equal(Vector2.UnitX, router.GetFrame(1).Aim);
+    }
+
+    [Fact]
+    public void FireEdgesAreIndependent() {
+        var router = new LocalPlayerInputRouter();
+        router.Update(new KeyboardState(Keys.Enter), new KeyboardState(), default, default);
+
+        Assert.False(router.GetFrame(0).FireJustPressed);
+        Assert.True(router.GetFrame(1).FireJustPressed);
+    }
+
+    [Fact]
+    public void P1LeftClickFiresOnlyOnPressEdge() {
+        var router = new LocalPlayerInputRouter();
+        var released = MouseWithLeftButton(ButtonState.Released);
+        var pressed = MouseWithLeftButton(ButtonState.Pressed);
+
+        router.Update(new KeyboardState(), new KeyboardState(), pressed, released);
+        Assert.True(router.GetFrame(0).FireJustPressed);
+
+        router.Update(new KeyboardState(), new KeyboardState(), pressed, pressed);
+        Assert.False(router.GetFrame(0).FireJustPressed);
+    }
+
+    [Fact]
+    public void P1SpaceMineUsesPressEdge() {
+        var router = new LocalPlayerInputRouter();
+
+        router.Update(new KeyboardState(Keys.Space), new KeyboardState(), default, default);
+        Assert.True(router.GetFrame(0).MineJustPressed);
+
+        router.Update(new KeyboardState(Keys.Space), new KeyboardState(Keys.Space), default, default);
+        Assert.False(router.GetFrame(0).MineJustPressed);
+    }
+
+    [Fact]
+    public void P2RightShiftMineUsesPressEdge() {
+        var router = new LocalPlayerInputRouter();
+
+        router.Update(new KeyboardState(Keys.RightShift), new KeyboardState(), default, default);
+        Assert.True(router.GetFrame(1).MineJustPressed);
+
+        router.Update(new KeyboardState(Keys.RightShift), new KeyboardState(Keys.RightShift), default, default);
+        Assert.False(router.GetFrame(1).MineJustPressed);
+    }
+
+    [Fact]
+    public void P2DiagonalAimIsNormalized() {
+        var router = new LocalPlayerInputRouter();
+
+        router.Update(new KeyboardState(Keys.Up, Keys.Right), new KeyboardState(), default, default);
+
+        var aim = router.GetFrame(1).Aim;
+        Assert.InRange(aim.Length(), 0.9999f, 1.0001f);
+        Assert.True(aim.X > 0);
+        Assert.True(aim.Y < 0);
+    }
+
+    [Fact]
+    public void P2DefaultAimPointsUp() {
+        var router = new LocalPlayerInputRouter();
+
+        Assert.Equal(-Vector2.UnitY, router.GetFrame(1).Aim);
+        Assert.Equal(LocalAimSource.Direction, router.GetFrame(1).AimSource);
+    }
+
+    [Fact]
+    public void P1MousePositionIsItsAimVector() {
+        var router = new LocalPlayerInputRouter();
+
+        router.Update(new KeyboardState(), new KeyboardState(), MouseAt(123, 456), default);
+
+        Assert.Equal(new Vector2(123, 456), router.GetFrame(0).Aim);
+        Assert.Equal(LocalAimSource.Mouse, router.GetFrame(0).AimSource);
+    }
+
+    [Fact]
+    public void ShotPathBindingsAreIndependent() {
+        var router = new LocalPlayerInputRouter();
+
+        router.Update(new KeyboardState(Keys.Q), new KeyboardState(), default, default);
+        Assert.True(router.GetFrame(0).ShotPathHeld);
+        Assert.False(router.GetFrame(1).ShotPathHeld);
+
+        router.Update(new KeyboardState(Keys.P), new KeyboardState(), default, default);
+        Assert.False(router.GetFrame(0).ShotPathHeld);
+        Assert.True(router.GetFrame(1).ShotPathHeld);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(2)]
+    public void InvalidPlayerIdIsRejected(int playerId) {
+        var router = new LocalPlayerInputRouter();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => router.GetFrame(playerId));
+    }
+
+    private static MouseState MouseAt(int x, int y) =>
+        new(x, y, 0, ButtonState.Released, ButtonState.Released, ButtonState.Released, ButtonState.Released, ButtonState.Released);
+
+    private static MouseState MouseWithLeftButton(ButtonState leftButton) =>
+        new(0, 0, 0, leftButton, ButtonState.Released, ButtonState.Released, ButtonState.Released, ButtonState.Released);
+}

--- a/Tests/TanksRebirth.Tests/LocalPlayerInputRouterTests.cs
+++ b/Tests/TanksRebirth.Tests/LocalPlayerInputRouterTests.cs
@@ -37,6 +37,19 @@ public sealed class LocalPlayerInputRouterTests {
     }
 
     [Fact]
+    public void P2AimInputClearsWhenArrowIsReleased() {
+        var router = new LocalPlayerInputRouter();
+        router.Update(new KeyboardState(Keys.Right), new KeyboardState(), default, default);
+
+        Assert.Equal(Vector2.UnitX, router.GetFrame(1).AimInput);
+
+        router.Update(new KeyboardState(), new KeyboardState(Keys.Right), default, default);
+
+        Assert.Equal(Vector2.Zero, router.GetFrame(1).AimInput);
+        Assert.Equal(Vector2.UnitX, router.GetFrame(1).Aim);
+    }
+
+    [Fact]
     public void FireEdgesAreIndependent() {
         var router = new LocalPlayerInputRouter();
         router.Update(new KeyboardState(Keys.Enter), new KeyboardState(), default, default);
@@ -107,6 +120,7 @@ public sealed class LocalPlayerInputRouterTests {
         router.Update(new KeyboardState(), new KeyboardState(), MouseAt(123, 456), default);
 
         Assert.Equal(new Vector2(123, 456), router.GetFrame(0).Aim);
+        Assert.Equal(new Vector2(123, 456), router.GetFrame(0).AimInput);
         Assert.Equal(LocalAimSource.Mouse, router.GetFrame(0).AimSource);
     }
 

--- a/Tests/TanksRebirth.Tests/LocalSessionTests.cs
+++ b/Tests/TanksRebirth.Tests/LocalSessionTests.cs
@@ -1,0 +1,28 @@
+using TanksRebirth.GameContent.Systems.LocalCoop;
+using Xunit;
+
+namespace TanksRebirth.Tests;
+
+public sealed class LocalSessionTests {
+    [Fact]
+    public void SinglePlayerActivatesOnlyBlue() {
+        var session = new LocalSession();
+        session.StartSinglePlayer();
+
+        Assert.Equal(1, session.PlayerCount);
+        Assert.True(session.IsActivePlayer(0));
+        Assert.False(session.IsActivePlayer(1));
+    }
+
+    [Fact]
+    public void LocalCoopActivatesBlueAndRedOnly() {
+        var session = new LocalSession();
+        session.StartLocalCoop();
+
+        Assert.Equal(2, session.PlayerCount);
+        Assert.True(session.IsActivePlayer(0));
+        Assert.True(session.IsActivePlayer(1));
+        Assert.False(session.IsActivePlayer(2));
+        Assert.False(session.IsActivePlayer(3));
+    }
+}

--- a/Tests/TanksRebirth.Tests/SmokeTests.cs
+++ b/Tests/TanksRebirth.Tests/SmokeTests.cs
@@ -1,0 +1,9 @@
+using Xunit;
+
+namespace TanksRebirth.Tests;
+
+public sealed class SmokeTests
+{
+    [Fact]
+    public void TestRunnerStarts() => Assert.True(true);
+}

--- a/Tests/TanksRebirth.Tests/TanksRebirth.Tests.csproj
+++ b/Tests/TanksRebirth.Tests/TanksRebirth.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../TanksRebirth.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Note

I used Codex to implement a local co-op feature I wanted for Tanks Rebirth, including the optional POV split-screen mode. This is simply a proposed contribution, and it is entirely up to the project owner whether it fits the game and should be merged.

## Summary

- add a Local Co-op campaign option with independent controls for two player tanks on one computer
- support P1 keyboard and mouse plus P2 keyboard controls, two-player spawning, status HUD, and sudden-death campaign progression
- reuse the existing POV difficulty toggle to render Local Co-op as a horizontal split-screen, with P1 on top and P2 below
- give each POV player camera-relative movement, independent view controls, a compact per-view HUD, and survivor spectating after one tank is destroyed
- prevent connected or co-op play from triggering the debug shell shortcut and preserve existing single-player and online lives behavior
- add focused tests for session state, input routing, campaign rules, campaign path handling, and POV policy

## Controls

Standard Local Co-op:
- P1: WASD movement, mouse aim, left click fire, Space mine
- P2: I/J/K/L movement, arrow-key aim, Enter fire, Right Shift mine

POV Local Co-op:
- P1 top: WASD camera-relative movement, mouse yaw, left click fire, Space mine
- P2 bottom: I/J/K/L camera-relative movement, Left/Right arrow yaw, Enter fire, Right Shift mine

## Test plan

- [x] Rebased cleanly onto current master
- [x] Release test build completed successfully
- [x] 109 xUnit tests passed
- [x] Played through the local co-op entry flow and mission rendering on macOS
- [x] Verified P1/P2 status display, no lives counters in Local Co-op, and independent controls
- [x] Verified a separately packaged macOS build and all required game assets

Online multiplayer is intentionally unchanged and continues to use the original lives system.